### PR TITLE
Monitor endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "express-router": "^0.0.1"
+    "express-router": "^0.0.1",
+    "nanoid": "^5.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-router": "^0.0.1"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,13 +1,17 @@
 import express from 'express';
 import cors from 'cors';
 import router from './routes/api.js';
+import home from './routes/home.js'
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
-app.use('/', router);
+app.use('/', home);
+app.use('/api', router);
+
+
 
 
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,16 +1,14 @@
 import express from 'express';
 import cors from 'cors';
+import router from './routes/api.js';
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
-app.get('/', (_, res) => {
-  const message = "Welcome to Sundial! The world's greatest "
-    + "open-source cron job monitoring solution.";
-  
-  res.send(message);
-});
+app.use('/', router);
+
+
 
 export default app;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -2,30 +2,23 @@ import express from 'express';
 const router = express.Router();
 import { nanoid } from 'nanoid';
 
-router.get('/', (_, res) => {
-  const message = "Welcome to Sundial! The world's greatest "
-    + "open-source cron job monitoring solution.";
-  
-  res.send(message);
-});
-
-router.post('/api/endpoint/:id', (req, res) => {
+router.post('/endpoint/:id', (req, res) => {
   const body = req.body;
   console.log(body);
 
   res.status(200).end();
 });
 
-router.get('/api/monitors', async(req, res) => {
+router.get('/monitors', async(req, res) => {
   try {
     const monitors = await getMonitors();
     res.send(monitors);
   } catch (e) {
-    res.send(500).send('unable to get all monitors');
+    res.status(500).send('unable to get all monitors');
   }
 });
 
-router.post('/api/monitors', (req, res) => {
+router.post('/monitors', (req, res) => {
   const body = req.body; 
   const id = nanoid(10);
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,0 +1,18 @@
+import express from 'express';
+const router = express.Router();
+
+router.get('/', (_, res) => {
+  const message = "Welcome to Sundial! The world's greatest "
+    + "open-source cron job monitoring solution.";
+  
+  res.send(message);
+});
+
+router.post('/api/endpoint/:id', (req, res) => {
+  const body = req.body;
+  console.log(body);
+
+  res.status(200).end();
+});
+
+export default router;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,5 +1,6 @@
 import express from 'express';
 const router = express.Router();
+import { nanoid } from 'nanoid';
 
 router.get('/', (_, res) => {
   const message = "Welcome to Sundial! The world's greatest "
@@ -13,6 +14,28 @@ router.post('/api/endpoint/:id', (req, res) => {
   console.log(body);
 
   res.status(200).end();
+});
+
+router.get('/api/monitors', async(req, res) => {
+  try {
+    const monitors = await getMonitors();
+    res.send(monitors);
+  } catch (e) {
+    res.send(500).send('unable to get all monitors');
+  }
+});
+
+router.post('/api/monitors', (req, res) => {
+  const body = req.body; 
+  const id = nanoid(10);
+
+  try {
+    createMonitor(body, id);
+    const wrapperStr = createWrapper(id);
+    res.send(wrapperStr);
+  } catch(e) {
+    res.send(500).send('unable to create monitor');
+  }
 });
 
 export default router;

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -1,0 +1,9 @@
+import express from 'express';
+const router = express.Router();
+
+export default router.get('/', (_, res) => {
+  const message = "Welcome to Sundial! The world's greatest "
+    + "open-source cron job monitoring solution.";
+  
+  res.send(message);
+});


### PR DESCRIPTION
Three endpoints added:

- webhook endpoint
- create new/add monitor
- get all monitors

For adding monitor, I have two methods `createMonitor` and `wrapperStr` that will need to be created. Wasn't sure if `createMonitor` will be a db method or if adding to the db will happen after a monitor is created, so the route handler isn't currently async.

For getting all monitors, the method `getMonitors` will need to be created. I assumed that would be a db method, so the route handler is async.

All the endpoints are `/api/<something>`. 

Installed [nanoid](https://github.com/ai/nanoid) for UUIDs. I made the UUIDs to be length 10, but they can be made shorter/longer. Maybe this shouldn't be in routes, but wherever `createMonitor` is defined?