### PR TITLE
notifications with database integration

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -12,15 +12,14 @@ const credentials = {
 
 const pool = new Pool(credentials);
 
-const executeQuery = async (query) => {
+const executeQuery = async (query, ...params) => {
   const client = await pool.connect();
   try {
-    const result = await client.query(query);
+    const result = await client.query(query, params);
     return result.rows;
   } finally {
     client.release();
   }
-}
+};
 
 export default executeQuery;
-

--- a/src/db/mock_data/monitors.sql
+++ b/src/db/mock_data/monitors.sql
@@ -1,0 +1,2 @@
+INSERT INTO monitor (endpoint_key, name, schedule, command, next_expected_at)
+VALUES ('abcde', 'First monitor', '* * * * *', 'node index.js', CURRENT_TIMESTAMP);

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -1,0 +1,13 @@
+import executeQuery from './config.js';
+
+const getOverdue = async () => {
+  const GET_OVERDUE = 'SELECT * FROM monitor WHERE '
+    + 'next_expected_at < $1';
+  const result = await executeQuery(GET_OVERDUE, new Date());
+
+  return result;
+};
+
+export default {
+  getOverdue,
+};

--- a/src/jobs/notify.js
+++ b/src/jobs/notify.js
@@ -1,8 +1,4 @@
-/*
-algorithm:
-- get monitors where next_expected_at < current_time
-- write to a file for any such monitor with schedule data, 
-when it was expected, command and name
-*/
+import db from '../db/queries.js';
 
-console.log('Querying the database and notifying users');
+const dueNotifications = await db.getOverdue();
+console.log(dueNotifications);


### PR DESCRIPTION
- Added /db/queries.js: file structure mimics SQL Queries pull request but with different application. Discuss in daily scrum.
- Added query which gets all overdue monitors from the database - the comparison is done by passing `new Date()` as a parameter to postgresql
- Altered /jobs/notify.js: This now uses queries.js to make the call to the database and simply outputs all corresponding monitors to the console every minute
![image](https://github.com/Sundial-Inc/server/assets/102357760/22c93897-2354-43d0-abe0-f7dcfd65ea2f)
Further work: 
- Overdue jobs that have already been notified should not be output again for a specified amount of time. This requires some additional database attribute. Discuss in daily scrum