### PR TITLE
add monitor to DB

### DIFF
--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -13,13 +13,22 @@ const getMonitors = async (req, res) => {
 };
 
 const addMonitor = async (req, res) => {
-  const { schedule } = req.body;
+  const { ...monitorData } = req.body;
   const endpoint_key = nanoid(10);
+
+  const newMonitorData = {
+    endpoint_key,
+    ...monitorData
+  };
+
   try {
-    const response = await dbAddMonitor(endpoint_key, schedule);
+    if (!newMonitorData.schedule) {
+      return res.status(400).json({ error: 'Missing or incorrect schedule.' });
+    }
+    const response = await dbAddMonitor(newMonitorData);
     const monitor = response.rows[0];
-//     const wrapperStr = createWrapper(id);
-//     res.send(wrapperStr);
+    // const wrapperStr = createWrapper(id);
+    // res.send(wrapperStr);
     res.json(monitor);
   } catch (error) {
     console.error(error);

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -13,13 +13,33 @@ const dbGetAllMonitors = () => {
   return dbQuery(GET_MONITORS);
 };
 
-const dbAddMonitor = (...params) => {
+const dbAddMonitor = ( monitor ) => {
+  const columns = ['endpoint_key', 'schedule'];
+  const values = [monitor.endpoint_key, monitor.schedule];
+
+  if (monitor.name) {
+    columns.push('name');
+    values.push(monitor.name);
+  }
+
+  if (monitor.command) {
+    columns.push('command');
+    values.push(monitor.command);
+  }
+
+  if (monitor.grace_period) {
+    columns.push('grace_period');
+    values.push(monitor.grace_period);
+  }
+
+  const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');
+
   const ADD_MONITOR = `
-    INSERT INTO monitor (endpoint_key, schedule)
-    VALUES ($1, $2)
+    INSERT INTO monitor (${columns}) 
+    VALUES (${placeholders})
     RETURNING *;`;
 
-  return dbQuery(ADD_MONITOR,  params);
+  return dbQuery(ADD_MONITOR, ...values);
 };
 
 export {


### PR DESCRIPTION
- `addMonitor` in controllers accepts an object, adds an ID, and then only if the object contains a schedule does it pass that to the `dbAddMonitor` function
- `dbAddMonitor` in `queries` dynamically creates a query depending on the properties passed in. I briefly though about jus taking all the keys and values from the `monitor` object to create the `columsn` and `values` but I thought this secured our database more since only the specified columns can be written to


submitting the form adds it to the list of monitors in the database

<img width="1076" alt="Screen Shot 2023-10-17 at 3 35 17 PM" src="https://github.com/Sundial-Inc/server/assets/81483266/2382b97d-1120-45a0-9e6d-c40656290a9e">

excuse the postman, the monitors list doesnt display this yet
<img width="538" alt="Screen Shot 2023-10-17 at 3 35 45 PM" src="https://github.com/Sundial-Inc/server/assets/81483266/3d025042-0a32-47f3-b919-d6e512559afb">


I implemented one bit of error handling where if no schedule is provided the user gets an alert,
the backend sends a 400 and this error message.
<img width="1012" alt="Screen Shot 2023-10-17 at 3 45 41 PM" src="https://github.com/Sun
<img width="629" alt="Screen Shot 2023-10-17 at 3 47 27 PM" src="https://github.com/Sundial-Inc/server/assets/81483266/78e71cbb-6495-4cc3-9c11-71c8d915b317">
dial-Inc/server/assets/81483266/0d04ed5b-54a8-4916-9e02-06e642002c19">



