### PR TITLE
Add error-handling middleware

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import router from './routes/api.js';
 import home from './routes/home.js';
+import {errorLogger, errorResponder, invalidPathHandler} from './utils/errorHandler.js';
 
 const app = express();
 
@@ -10,5 +11,9 @@ app.use(express.json());
 
 app.use('/', home);
 app.use('/api', router);
+
+app.use(errorLogger);
+app.use(errorResponder);
+app.use(invalidPathHandler);
 
 export default app;

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -6,13 +6,14 @@ const getMonitors = async (req, res) => {
     const response = await dbGetAllMonitors();
     const monitors = response.rows;
     res.json(monitors);
-  } catch (error) {
+  } catch (error) { 
     console.error(error);
+
     res.status(500).json({ error: 'Could not fetch monitors.' });
   }
 };
 
-const addMonitor = async (req, res) => {
+const addMonitor = async (req, res, next) => {
   const { ...monitorData } = req.body;
   const endpoint_key = nanoid(10);
 
@@ -23,7 +24,12 @@ const addMonitor = async (req, res) => {
 
   try {
     if (!newMonitorData.schedule) {
-      return res.status(400).json({ error: 'Missing or incorrect schedule.' });
+      const error = new Error("Schedule required.")
+
+      error.statusCode = 400
+      error.statusMessage = 'Missing or incorrect schedule.';
+
+      throw error;
     }
     const response = await dbAddMonitor(newMonitorData);
     const monitor = response.rows[0];
@@ -31,8 +37,11 @@ const addMonitor = async (req, res) => {
     // res.send(wrapperStr);
     res.json(monitor);
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Unable to create monitor.' });
+    if (error.statusCode === 400) {
+      next(error);
+    } else {
+      res.status(500).json({ error: 'Unable to create monitor.' });
+    }
   }
 };
 

--- a/src/db/mock_data/monitors.sql
+++ b/src/db/mock_data/monitors.sql
@@ -1,2 +1,3 @@
 INSERT INTO monitor (endpoint_key, name, schedule, command, next_expected_at)
-VALUES ('abcde', 'First monitor', '* * * * *', 'node index.js', CURRENT_TIMESTAMP);
+VALUES ('abcde', 'First monitor', '* * * * *', 'node index.js', CURRENT_TIMESTAMP),
+      ('a12b34', 'Second monitor', '1 * * * 2', 'echo "Hello Mary" >> /Users/mary/test/crontest.txt', CURRENT_TIMESTAMP);

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -1,19 +1,22 @@
 import dbQuery from '../db/config.js';
 
-const dbGetOverdue = () => {
+const dbGetOverdue = async () => {
   const GET_OVERDUE = 'SELECT * FROM monitor WHERE '
     + 'next_expected_at < $1';
 
-  return dbQuery(GET_OVERDUE, new Date());
+  const result = await dbQuery(GET_OVERDUE, new Date());
+
+  return result;
 };
 
-const dbGetAllMonitors = () => {
+const dbGetAllMonitors = async () => {
   const GET_MONITORS = 'SELECT * FROM monitor';
 
-  return dbQuery(GET_MONITORS);
+  const result = await dbQuery(GET_MONITORS);
+  return result;
 };
 
-const dbAddMonitor = ( monitor ) => {
+const dbAddMonitor = async ( monitor ) => {
   const columns = ['endpoint_key', 'schedule'];
   const values = [monitor.endpoint_key, monitor.schedule];
 
@@ -39,7 +42,8 @@ const dbAddMonitor = ( monitor ) => {
     VALUES (${placeholders})
     RETURNING *;`;
 
-  return dbQuery(ADD_MONITOR, ...values);
+  const result = dbQuery(ADD_MONITOR, ...values);
+  return result;
 };
 
 export {

--- a/src/routes/error.js
+++ b/src/routes/error.js
@@ -1,0 +1,6 @@
+import express from 'express';
+const router = express.Router();
+
+export default router.get('/error', (req, res) => {
+  res.status(404).send("The URL you are trying to reach does not exist.")
+});

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,0 +1,15 @@
+export const errorLogger = (error, req, res, next) => { 
+  console.error(error);
+  next(error);
+}
+
+export const errorResponder = (error, req, res, next) => {
+  res.header("Content-Type", 'application/json');
+    
+  const status = error.statusCode || 400;
+  res.status(status).send(error.message);
+}
+
+export const invalidPathHandler = (req, res) => {
+  res.redirect('/error');
+}


### PR DESCRIPTION
Created the `errorHandler.js` file with three error handling middleware (technically `invalidPathHandler` is not error handling because it does not have `error` as a parameter, but still...):

- `errorLogger`: to log errors to the console
- `errorResponder`: to handle errors of any type or return a general 400
- invalidPathHandler: to handle any invalid URLs and redirect them to a `/error `route (in the future, we can make a custom error page)

Currently, only `addMonitor` will use the `errorResponder` function; this is to catch any requests made without the necessary parameters. There is still custom error handling within `addMonitor` and `getMonitors`, related to the db returning an error – I'm not totally sure that those should go to the error handler middleware because they are not standard errors. We can discuss during scrum (although I think this is also not pertinent to 'testable').

I also made the queries in `queries.js` to be async. They weren't, but they'll need to be when we actually start filling the db with data/asking the db to do more complex queries or work (queries right now return instantaneously with a near-empty db, which is why I think we haven't noticed anything).