### PR TITLE
Sql queries - alert updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "bree": "^9.1.3",
     "cors": "^2.8.5",
+    "cron-parser": "^4.9.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-router": "^0.0.1",

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -19,8 +19,8 @@ const addMonitor = async (req, res) => {
   const { schedule } = req.body;
   const endpoint_key = nanoid(10);
   try {
-    // await dbQuery(queryAddMonitor, [endpoint_id, schedule, command]);
-    // const wrapperStr = createWrapper(endpoint_id, schedule, command);
+    // await dbQuery(queryAddMonitor, [endpoint_key, schedule, command]);
+    // const wrapperStr = createWrapper(endpoint_key, schedule, command);
     // res.send(wrapperStr);
     const response = await dbAddMonitor([endpoint_key, schedule]);
     const monitor = response.rows[0];
@@ -30,7 +30,6 @@ const addMonitor = async (req, res) => {
     res.status(500).json({ error: 'Unable to create monitor.' });
   }
 };
-
 
 export {
   getMonitors,

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import { dbGetAllMonitors, dbAddMonitor } from '../db/queries.js';
+// import { createWrapper, parse } from '../utils/cronJobs.js';
 
 const getMonitors = async (req, res) => {
   try {
@@ -18,10 +19,11 @@ const addMonitor = async (req, res) => {
   const { schedule } = req.body;
   const endpoint_key = nanoid(10);
   try {
+    // await dbQuery(queryAddMonitor, [endpoint_id, schedule, command]);
+    // const wrapperStr = createWrapper(endpoint_id, schedule, command);
+    // res.send(wrapperStr);
     const response = await dbAddMonitor([endpoint_key, schedule]);
     const monitor = response.rows[0];
-//     const wrapperStr = createWrapper(id);
-//     res.send(wrapperStr);
     res.json(monitor);
   } catch (error) {
     console.error(error);

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -13,6 +13,8 @@ const getMonitors = async (req, res) => {
 };
 
 const addMonitor = async (req, res) => {
+  // const { cronJob } = req.body;
+  // const { schedule, command } = parseCronJob(cronJob);
   const { schedule } = req.body;
   const endpoint_key = nanoid(10);
   try {

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -1,6 +1,5 @@
 import { nanoid } from 'nanoid';
 import { dbGetAllMonitors, dbAddMonitor } from '../db/queries.js';
-// import { createWrapper, parse } from '../utils/cronJobs.js';
 
 const getMonitors = async (req, res) => {
   try {
@@ -14,14 +13,9 @@ const getMonitors = async (req, res) => {
 };
 
 const addMonitor = async (req, res) => {
-  // const { cronJob } = req.body;
-  // const { schedule, command } = parseCronJob(cronJob);
   const { schedule } = req.body;
   const endpoint_key = nanoid(10);
   try {
-    // await dbQuery(queryAddMonitor, [endpoint_key, schedule, command]);
-    // const wrapperStr = createWrapper(endpoint_key, schedule, command);
-    // res.send(wrapperStr);
     const response = await dbAddMonitor([endpoint_key, schedule]);
     const monitor = response.rows[0];
     res.json(monitor);

--- a/src/db/ddl/monitor.sql
+++ b/src/db/ddl/monitor.sql
@@ -8,7 +8,7 @@ CREATE TABLE monitor (
   command text,
   active boolean NOT NULL DEFAULT true,
   failing boolean NOT NULL DEFAULT false,
-  next_expected_at timestamp,
+  next_alert timestamp,
   created_at timestamp DEFAULT CURRENT_TIMESTAMP,
   grace_period int NOT NULL DEFAULT 30, -- TESTING PURPOSES ONLY
   PRIMARY KEY (id)

--- a/src/db/init.sh
+++ b/src/db/init.sh
@@ -1,7 +1,15 @@
-#run with 'bash filename'
+#!/bin/bash
 
-dropdb sundial
-createdb sundial
-psql -d sundial < ./ddl/monitor.sql
-psql -d sundial < ./ddl/run.sql
-psql -d sundial < ./ddl/ping.sql
+# Unless the sundial database exists and contains both monitor, run and ping tables, reset database
+
+if ! $(psql -lqt | cut -d \| -f 1 | grep -qw "sundial" && \
+       psql -d "sundial" -c "\dt" | grep -q "monitor" && \
+       psql -d "sundial" -c "\dt" | grep -q "ping" && \
+       psql -d "sundial" -c "\dt" | grep -q "run" ); then
+
+  dropdb sundial
+  createdb sundial
+  psql -d sundial < ./ddl/monitor.sql
+  psql -d sundial < ./ddl/run.sql
+  psql -d sundial < ./ddl/ping.sql
+fi

--- a/src/db/init.sh
+++ b/src/db/init.sh
@@ -12,4 +12,5 @@ if ! $(psql -lqt | cut -d \| -f 1 | grep -qw "sundial" && \
   psql -d sundial < ./ddl/monitor.sql
   psql -d sundial < ./ddl/run.sql
   psql -d sundial < ./ddl/ping.sql
+  # psql -d sundial < ./mock_data/monitors.sql
 fi

--- a/src/db/mock_data/monitors.sql
+++ b/src/db/mock_data/monitors.sql
@@ -1,2 +1,2 @@
 INSERT INTO monitor (endpoint_key, name, schedule, command, next_expected_at)
-VALUES ('abcde', 'First monitor', '* * * * *', 'node index.js', CURRENT_TIMESTAMP);
+VALUES ('abcde', 'First monitor', '* * 3 * *', 'node index.js', CURRENT_TIMESTAMP);

--- a/src/db/mock_data/monitors.sql
+++ b/src/db/mock_data/monitors.sql
@@ -1,2 +1,5 @@
-INSERT INTO monitor (endpoint_key, name, schedule, command, next_expected_at)
-VALUES ('abcde', 'First monitor', '* * 3 * *', 'node index.js', CURRENT_TIMESTAMP);
+INSERT INTO monitor (endpoint_key, name, schedule, command, next_alert)
+VALUES ('abcde', 'First monitor', '* * 3 * *', 'node index.js', CURRENT_TIMESTAMP),
+('abcdef', 'Second monitor', '* * 3 * *', 'node index.js', CURRENT_TIMESTAMP),
+('a', 'Third monitor', '* * 3 * *', 'node index.js', CURRENT_TIMESTAMP),
+('ab', 'Fourth monitor', '* * 3 * *', 'node index.js', CURRENT_TIMESTAMP);

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -4,31 +4,33 @@ import parser from 'cron-parser';
 
 const getOverdue = async () => {
   const GET_OVERDUE = 'SELECT * FROM monitor WHERE '
-    + 'next_expected_at < $1';
+    + 'next_alert < $1';
   const result = await executeQuery(GET_OVERDUE, new Date());
 
   return result;
 };
 
-const dbUpdateNextExpected = async (endpoint_key) => {
-  const schedule = await dbQuery(
-    `SELECT schedule 
+const dbUpdateNextAlert = async (endpoint_key) => {
+  const results = await dbQuery(
+    `SELECT *
     FROM monitor
-    WHERE endpoint_key = ${endpoint_key}
-  `);
+    WHERE endpoint_key = $1;
+  `, [endpoint_key]);
 
-  const nextExpectedAt = parser.parseExpression(
-    schedule,
+  const target = results.rows[0];
+
+  const nextAlert = parser.parseExpression(
+    target.schedule,
     { currentDate: new Date() }
-  );
+  ).next()._date.ts +
+    target.grace_period * 1000;
 
   return dbQuery(`
     UPDATE monitor
-    SET next_expected_at = $2
+    SET next_alert = (to_timestamp($2 / 1000.0))
     WHERE endpoint_key = $1;`,
-  [endpoint_key, nextExpectedAt]);
+  [endpoint_key, nextAlert]);
 };
-
 
 const dbGetAllMonitors = () => {
   return dbQuery('SELECT * FROM monitor');
@@ -38,13 +40,13 @@ const dbAddMonitor = (params) => {
   return dbQuery(`
     INSERT INTO monitor (endpoint_key, schedule)
     VALUES ($1, $2)
-    RETURNING *;`, 
+    RETURNING *;`,
     params);
 };
 
 export {
   dbGetAllMonitors,
   dbAddMonitor,
-  dbUpdateNextExpected,
+  dbUpdateNextAlert,
   getOverdue
 };

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -2,6 +2,12 @@
 import executeQuery from './config.js';
 import dbQuery from '../db/config.js';
 
+// const dbAddMonitor = `
+//   INSERT INTO monitor (endpoint_key, schedule, command)
+//   VALUES ($1, $2, $3)
+//   RETURNING *;
+// `;
+
 const getOverdue = async () => {
   const GET_OVERDUE = 'SELECT * FROM monitor WHERE '
     + 'next_expected_at < $1';

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -2,12 +2,6 @@ import executeQuery from './config.js';
 import dbQuery from '../db/config.js';
 import parser from 'cron-parser';
 
-// const dbAddMonitor = `
-//   INSERT INTO monitor (endpoint_key, schedule, command)
-//   VALUES ($1, $2, $3)
-//   RETURNING *;
-// `;
-
 const getOverdue = async () => {
   const GET_OVERDUE = 'SELECT * FROM monitor WHERE '
     + 'next_expected_at < $1';
@@ -16,7 +10,7 @@ const getOverdue = async () => {
   return result;
 };
 
-const dbUpdateNextExpected = async (endpoint_key, currentDate) => {
+const dbUpdateNextExpected = async (endpoint_key) => {
   const schedule = await dbQuery(
     `SELECT schedule 
     FROM monitor

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -65,7 +65,20 @@ const dbAddMonitor = ( monitor ) => {
   return dbQuery(ADD_MONITOR, ...values);
 };
 
+const dbMonitorFailure = (ids) => {
+  const updateQuery = `
+    UPDATE monitor AS t
+    SET failing = false,
+        next_alert = t.next_alert + (t.grace_period * interval '1 second')
+    FROM (SELECT id, grace_period FROM monitor WHERE id = ANY($1)) AS g
+    WHERE t.id = g.id;
+  `;
+
+  return dbQuery(updateQuery, [ids]);
+};
+
 export {
+  dbMonitorFailure,
   dbGetAllMonitors,
   dbUpdateNextAlert,
   dbAddMonitor,

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -23,7 +23,7 @@ const dbUpdateNextAlert = async (endpoint_key) => {
   ).next()._date.ts +
     target.grace_period * 1000;
 
-  return dbQuery(`
+  return await dbQuery(`
     UPDATE monitor
     SET next_alert = (to_timestamp($2 / 1000.0))
     WHERE endpoint_key = $1;`,
@@ -65,7 +65,7 @@ const dbAddMonitor = ( monitor ) => {
   return dbQuery(ADD_MONITOR, ...values);
 };
 
-const dbMonitorFailure = (ids) => {
+const dbMonitorFailure = async (ids) => {
   const updateQuery = `
     UPDATE monitor AS t
     SET failing = false,
@@ -74,7 +74,7 @@ const dbMonitorFailure = (ids) => {
     WHERE t.id = g.id;
   `;
 
-  return dbQuery(updateQuery, [ids]);
+  return await dbQuery(updateQuery, [ids]);
 };
 
 export {

--- a/src/jobs/notify.js
+++ b/src/jobs/notify.js
@@ -1,10 +1,11 @@
 import { dbGetOverdue } from '../db/queries.js';
-
+import { update } from '../utils/notificationUpdates.js';
 (async () => {
   try {
     const response = await dbGetOverdue();
     const dueNotifications = response.rows;
     console.log(dueNotifications);
+    update(dueNotifications);
   } catch (error) {
     console.error('Failed retrieving overdue job from database.', error);
   }

--- a/src/jobs/notify.js
+++ b/src/jobs/notify.js
@@ -5,7 +5,7 @@ import { update } from '../utils/notificationUpdates.js';
     const response = await dbGetOverdue();
     const dueNotifications = response.rows;
     console.log(dueNotifications);
-    update(dueNotifications);
+    await update(dueNotifications);
   } catch (error) {
     console.error('Failed retrieving overdue job from database.', error);
   }

--- a/src/utils/cronJobs.js
+++ b/src/utils/cronJobs.js
@@ -5,8 +5,8 @@
 //   return { schedule, command };
 // };
 
-// const createWrapper = (endpoint_id, schedule, command) => {
-//   return `${schedule} sundial exec ${endpoint_id} ${command}`;
+// const createWrapper = (endpoint_key, schedule, command) => {
+//   return `${schedule} sundial exec ${endpoint_id==key} ${command}`;
 // };
 
 // export default { createWrapper, parse };

--- a/src/utils/cronJobs.js
+++ b/src/utils/cronJobs.js
@@ -1,0 +1,12 @@
+// const parse = (cronJob) => {
+//   const arr = cronJob.split(' ');
+//   const schedule = arr.slice(0, 5).join(' ');
+//   const command = arr.slice(5).join(' ');
+//   return { schedule, command };
+// };
+
+// const createWrapper = (endpoint_id, schedule, command) => {
+//   return `${schedule} sundial exec ${endpoint_id} ${command}`;
+// };
+
+// export default { createWrapper, parse };

--- a/src/utils/notificationUpdates.js
+++ b/src/utils/notificationUpdates.js
@@ -1,0 +1,8 @@
+import { dbMonitorFailure } from '../db/queries.js';
+
+const update = (rows) => {
+  const ids = rows.map(({ id }) => id);
+  return dbMonitorFailure(ids);
+};
+
+export default update;

--- a/src/utils/notificationUpdates.js
+++ b/src/utils/notificationUpdates.js
@@ -1,8 +1,8 @@
 import { dbMonitorFailure } from '../db/queries.js';
 
-const update = (rows) => {
+const update = async (rows) => {
   const ids = rows.map(({ id }) => id);
-  return dbMonitorFailure(ids);
+  return await dbMonitorFailure(ids);
 };
 
 export default update;


### PR DESCRIPTION
- Added query for updating next_alert based on the current time, grace period and schedule. Should be called when when pings (not implemented yet) come in.
- Added additional update action to the notification system. Added query + helper function such that when a notification for a monitor goes off, the database updates its state to failing and updates the next alert time.
- Added conditional to /db/init.sh such that the database only resets if the database with all of its tables doesn't exist. This allows for us to persist data even if we run it multiple times.