### PR TITLE
Refactoring db queries and testing error handling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import router from './routes/api.js';
 import home from './routes/home.js';
-import {errorLogger, errorResponder, invalidPathHandler} from './utils/errorHandler.js';
+import { errorLogger, errorResponder, invalidPathHandler } from './utils/errorHandler.js';
 
 const app = express();
 

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -1,15 +1,12 @@
 import { nanoid } from 'nanoid';
 import { dbGetAllMonitors, dbAddMonitor } from '../db/queries.js';
 
-const getMonitors = async (req, res) => {
+const getMonitors = async (req, res, next) => {
   try {
-    const response = await dbGetAllMonitors();
-    const monitors = response.rows;
+    const monitors = await dbGetAllMonitors();
     res.json(monitors);
-  } catch (error) { 
-    console.error(error);
-
-    res.status(500).json({ error: 'Could not fetch monitors.' });
+  } catch (error) {
+    next(error);
   }
 };
 
@@ -22,24 +19,20 @@ const addMonitor = async (req, res, next) => {
     ...monitorData
   };
 
+  if (!newMonitorData.schedule) {
+    const error = new Error('Schedule required.');
+    error.statusCode = 400;
+    error.statusMessage = 'Missing or incorrect schedule.';
+
+    return next(error);
+  }
+
   try {
-    if (!newMonitorData.schedule) {
-      const error = new Error("Schedule required.")
-
-      error.statusCode = 400
-      error.statusMessage = 'Missing or incorrect schedule.';
-
-      throw error;
-    }
-    const response = await dbAddMonitor(newMonitorData);
-    const monitor = response.rows[0];
+    const monitor = await dbAddMonitor(newMonitorData);
+    console.log('the monitor', monitor);
     res.json(monitor);
   } catch (error) {
-    if (error.statusCode === 400) {
-      next(error);
-    } else {
-      res.status(500).json({ error: 'Unable to create monitor.' });
-    }
+    next(error);
   }
 };
 

--- a/src/controllers/ping.js
+++ b/src/controllers/ping.js
@@ -1,25 +1,30 @@
 import {
   dbGetMonitorByEndpointKey,
-  dbMonitorRecovery,
+  dbUpdateMonitorRecovered,
   dbUpdateNextAlert,
   dbAddPing,
 } from '../db/queries.js';
 
-const addPing = async (req, res) => {
+const addPing = async (req, res, next) => {
   try {
     const endpoint_key = req.params.endpoint_key;
     const monitor = await dbGetMonitorByEndpointKey(endpoint_key);
+    if (!monitor) {
+      throw new Error('Unable to find monitor associated with that endpoint.');
+    }
 
     dbAddPing(monitor.id);
 
     if (monitor.failing) {
-      dbMonitorRecovery(monitor.id);
+      dbUpdateMonitorRecovered(monitor.id);
     }
 
-    dbUpdateNextAlert(endpoint_key);
+    dbUpdateNextAlert(monitor);
     res.status(200).send();
   } catch(error) {
-    res.status(500).send(error);
+    console.log(error.message, "The error from the last catch block");
+
+    next(error);
   }
 };
 

--- a/src/controllers/ping.js
+++ b/src/controllers/ping.js
@@ -13,13 +13,13 @@ const addPing = async (req, res, next) => {
       throw new Error('Unable to find monitor associated with that endpoint.');
     }
 
-    await dbAddPing(monitor.id); // need return value?
+    await dbAddPing(monitor.id);
 
     if (monitor.failing) {
-      await dbUpdateMonitorRecovered(monitor.id); // need return value?
+      await dbUpdateMonitorRecovered(monitor.id);
     }
 
-    await dbUpdateNextAlert(monitor); // need return value?
+    await dbUpdateNextAlert(monitor);
     res.status(200).send();
   } catch(error) {
     next(error);

--- a/src/controllers/ping.js
+++ b/src/controllers/ping.js
@@ -13,17 +13,15 @@ const addPing = async (req, res, next) => {
       throw new Error('Unable to find monitor associated with that endpoint.');
     }
 
-    dbAddPing(monitor.id);
+    await dbAddPing(monitor.id); // need return value?
 
     if (monitor.failing) {
-      dbUpdateMonitorRecovered(monitor.id);
+      await dbUpdateMonitorRecovered(monitor.id); // need return value?
     }
 
-    dbUpdateNextAlert(monitor);
+    await dbUpdateNextAlert(monitor); // need return value?
     res.status(200).send();
   } catch(error) {
-    console.log(error.message, "The error from the last catch block");
-
     next(error);
   }
 };

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -33,8 +33,7 @@ const dbUpdateNextAlert = async (monitor) => {
   ).next()._date.ts +
     monitor.grace_period * 1000;
 
-  const rows = await handleDatabaseQuery(UPDATE_ALERT, errorMessage, monitor.endpoint_key, nextAlert);
-  return rows[0]; //necessary to return?
+  return await handleDatabaseQuery(UPDATE_ALERT, errorMessage, monitor.endpoint_key, nextAlert);
 };
 
 const dbGetMonitorByEndpointKey = async (endpoint_key) => {
@@ -108,8 +107,7 @@ const dbUpdateMonitorRecovered = async (id) => {
   `;
   const errorMessage = 'Unable to update `failing` state in database.';
 
-  const rows = await handleDatabaseQuery(UPDATE_RECOVERY, errorMessage, id);
-  return rows[0]; //necessary to return?
+  return await handleDatabaseQuery(UPDATE_RECOVERY, errorMessage, id);
 };
 
 const dbAddPing = async (monitor_id) => {
@@ -120,8 +118,7 @@ const dbAddPing = async (monitor_id) => {
   `;
   const errorMessage = 'Unable to add ping to database.';
 
-  const pings = await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
-  return pings[0]; // necessary to return?
+  return await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
 };
 
 export {

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -97,7 +97,7 @@ const dbUpdateFailingMonitors = async (ids) => {
   `;
   const errorMessage = 'Unable to update failed monitors next alert or failing state in database.';
 
-  return await handleDatabaseQuery(UPDATE_FAILING, errorMessage, [ids]); //necessary to return?
+  return await handleDatabaseQuery(UPDATE_FAILING, errorMessage, [ids]);
 };
 
 const dbUpdateMonitorRecovered = async (id) => {
@@ -122,7 +122,7 @@ const dbAddPing = async (monitor_id) => {
   const errorMessage = 'Unable to add ping to database.';
 
   const pings = await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
-  return pings[0]; // need return?
+  return pings[0]; // necessary to return?
 };
 
 export {

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -45,8 +45,8 @@ const dbGetMonitorByEndpointKey = async (endpoint_key) => {
   `;
   const errorMessage = 'Unable to fetch monitor by endpoint key from database.';
 
-  const rows = await handleDatabaseQuery(GET_MONITOR, errorMessage, endpoint_key);
-  return rows[0];
+  const monitor = await handleDatabaseQuery(GET_MONITOR, errorMessage, endpoint_key);
+  return monitor[0];
 };
 
 const dbGetAllMonitors = async () => {
@@ -121,8 +121,8 @@ const dbAddPing = async (monitor_id) => {
   `;
   const errorMessage = 'Unable to add ping to database.';
 
-  const rows = await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
-  return rows[0]; //necessary to return?
+  const pings = await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
+  return pings[0]; // need return?
 };
 
 export {

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -7,7 +7,6 @@ const handleDatabaseQuery = async (query, errorMessage, ...params) => {
     return result.rows;
   } catch (error) {
     error.message = errorMessage || 'Unable to perform database operation.';
-    console.log("Error from db", error.message);
     throw error;
   }
 };

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -1,31 +1,41 @@
-import dbQuery from '../db/config.js';
+import dbQuery from './config.js';
 import parser from 'cron-parser';
+
+const handleDatabaseQuery = async (query, errorMessage, ...params) => {
+  try {
+    const result = await dbQuery(query, ...params);
+    return result.rows;
+  } catch (error) {
+    error.message = errorMessage || 'Unable to perform database operation.';
+    console.log("Error from db", error.message);
+    throw error;
+  }
+};
 
 const dbGetOverdue = async () => {
   const GET_OVERDUE = 'SELECT * FROM monitor WHERE '
     + 'next_alert < $1';
+  const errorMessage = 'Unable to get overdue jobs from database.';
 
-  const result = await dbQuery(GET_OVERDUE, new Date());
-
-  return result;
+  return await handleDatabaseQuery(GET_OVERDUE, errorMessage, new Date());
 };
 
-const dbUpdateNextAlert = async (endpoint_key) => {
-  const target = await dbGetMonitorByEndpointKey(endpoint_key);
-
-  const nextAlert = parser.parseExpression(
-    target.schedule,
-    { currentDate: new Date() }
-  ).next()._date.ts +
-    target.grace_period * 1000;
-
+const dbUpdateNextAlert = async (monitor) => {
   const UPDATE_ALERT = `
     UPDATE monitor
     SET next_alert = (to_timestamp($2 / 1000.0))
     WHERE endpoint_key = $1;
   `;
+  const errorMessage = 'Unable to update next alert time in database.';
 
-  return await dbQuery(UPDATE_ALERT, endpoint_key, nextAlert);
+  const nextAlert = parser.parseExpression(
+    monitor.schedule,
+    { currentDate: new Date() }
+  ).next()._date.ts +
+    monitor.grace_period * 1000;
+
+  const rows = await handleDatabaseQuery(UPDATE_ALERT, errorMessage, monitor.endpoint_key, nextAlert);
+  return rows[0]; //necessary to return?
 };
 
 const dbGetMonitorByEndpointKey = async (endpoint_key) => {
@@ -33,16 +43,17 @@ const dbGetMonitorByEndpointKey = async (endpoint_key) => {
     SELECT * FROM monitor
     WHERE endpoint_key = $1
   `;
+  const errorMessage = 'Unable to fetch monitor by endpoint key from database.';
 
-  const result = await dbQuery(GET_MONITOR, endpoint_key);
-  return result.rows[0];
+  const rows = await handleDatabaseQuery(GET_MONITOR, errorMessage, endpoint_key);
+  return rows[0];
 };
 
 const dbGetAllMonitors = async () => {
   const GET_MONITORS = 'SELECT * FROM monitor';
+  const errorMessage = 'Unable to fetch monitors from database.';
 
-  const result = await dbQuery(GET_MONITORS);
-  return result;
+  return await handleDatabaseQuery(GET_MONITORS, errorMessage);
 };
 
 const dbAddMonitor = async ( monitor ) => {
@@ -70,12 +81,13 @@ const dbAddMonitor = async ( monitor ) => {
     INSERT INTO monitor (${columns}) 
     VALUES (${placeholders})
     RETURNING *;`;
+  const errorMessage = 'Unable to add a monitor to database.';
 
-  const result = dbQuery(ADD_MONITOR, ...values);
-  return result;
+  const rows = await handleDatabaseQuery(ADD_MONITOR, errorMessage, ...values);
+  return rows[0];
 };
 
-const dbMonitorsFailure = async (ids) => {
+const dbUpdateFailingMonitors = async (ids) => {
   const UPDATE_FAILING = `
     UPDATE monitor AS t
     SET failing = true,
@@ -83,20 +95,22 @@ const dbMonitorsFailure = async (ids) => {
     FROM (SELECT id, grace_period FROM monitor WHERE id = ANY($1)) AS g
     WHERE t.id = g.id;
   `;
+  const errorMessage = 'Unable to update failed monitors next alert or failing state in database.';
 
-  return await dbQuery(UPDATE_FAILING, [ids]);
+  return await handleDatabaseQuery(UPDATE_FAILING, errorMessage, [ids]); //necessary to return?
 };
 
-const dbMonitorRecovery = async (id) => {
+const dbUpdateMonitorRecovered = async (id) => {
   const UPDATE_RECOVERY = `
     UPDATE monitor
     SET failing = false
     WHERE monitor.id = $1
     RETURNING *
   `;
+  const errorMessage = 'Unable to update `failing` state in database.';
 
-  const result = await dbQuery(UPDATE_RECOVERY, id);
-  return result.rows[0];
+  const rows = await handleDatabaseQuery(UPDATE_RECOVERY, errorMessage, id);
+  return rows[0]; //necessary to return?
 };
 
 const dbAddPing = async (monitor_id) => {
@@ -105,14 +119,15 @@ const dbAddPing = async (monitor_id) => {
     VALUES ($1)
     RETURNING *
   `;
+  const errorMessage = 'Unable to add ping to database.';
 
-  const result = await dbQuery(ADD_PING, monitor_id);
-  return result.rows[0];
+  const rows = await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
+  return rows[0]; //necessary to return?
 };
 
 export {
-  dbMonitorsFailure,
-  dbMonitorRecovery,
+  dbUpdateFailingMonitors,
+  dbUpdateMonitorRecovered,
   dbGetMonitorByEndpointKey,
   dbGetAllMonitors,
   dbUpdateNextAlert,

--- a/src/jobs/notify.js
+++ b/src/jobs/notify.js
@@ -2,8 +2,7 @@ import { dbGetOverdue } from '../db/queries.js';
 import { update } from '../utils/notificationUpdates.js';
 (async () => {
   try {
-    const response = await dbGetOverdue();
-    const dueNotifications = response.rows;
+    const dueNotifications = await dbGetOverdue();
     console.log(dueNotifications);
     await update(dueNotifications);
   } catch (error) {

--- a/src/jobs/notify.js
+++ b/src/jobs/notify.js
@@ -1,10 +1,12 @@
 import { dbGetOverdue } from '../db/queries.js';
-import { update } from '../utils/notificationUpdates.js';
+import { updateFailed } from '../utils/notificationUpdates.js';
 (async () => {
   try {
-    const dueNotifications = await dbGetOverdue();
-    console.log(dueNotifications);
-    await update(dueNotifications);
+    const overdueMonitors = await dbGetOverdue();
+    console.log(overdueMonitors);
+    if (overdueMonitors.length > 0) {
+      await updateFailed(overdueMonitors);
+    }
   } catch (error) {
     console.error('Failed retrieving overdue job from database.', error);
   }

--- a/src/routes/error.js
+++ b/src/routes/error.js
@@ -2,5 +2,5 @@ import express from 'express';
 const router = express.Router();
 
 export default router.get('/error', (req, res) => {
-  res.status(404).send("The URL you are trying to reach does not exist.")
+  res.status(404).send('The URL you are trying to reach does not exist.')
 });

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,11 +1,10 @@
 export const errorLogger = (error, req, res, next) => {
-  console.error(error, 'in error logger');
+  console.error(error, 'from error logger');
   next(error);
 };
 
 export const errorResponder = (error, req, res) => {
   res.setHeader('Content-Type', 'application/json');
-  console.log('in error responder');
 
   const status = error.statusCode || 400;
   res.status(status).send(error.message);

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,15 +1,16 @@
-export const errorLogger = (error, req, res, next) => { 
-  console.error(error);
+export const errorLogger = (error, req, res, next) => {
+  console.error(error, 'in error logger');
   next(error);
-}
+};
 
-export const errorResponder = (error, req, res, next) => {
-  res.header("Content-Type", 'application/json');
-    
+export const errorResponder = (error, req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  console.log('in error responder');
+
   const status = error.statusCode || 400;
   res.status(status).send(error.message);
-}
+};
 
 export const invalidPathHandler = (req, res) => {
   res.redirect('/error');
-}
+};

--- a/src/utils/notificationUpdates.js
+++ b/src/utils/notificationUpdates.js
@@ -1,9 +1,13 @@
-import { dbMonitorsFailure } from '../db/queries.js';
+import { dbUpdateFailingMonitors } from '../db/queries.js';
 
 const update = async (rows) => {
   const ids = rows.map(({ id }) => id);
   if (ids.length !== 0) {
-    await dbMonitorsFailure(ids);
+    try {
+      await dbUpdateFailingMonitors(ids);
+    } catch (error) {
+      console.log(error);
+    }
   }
 };
 

--- a/src/utils/notificationUpdates.js
+++ b/src/utils/notificationUpdates.js
@@ -1,16 +1,14 @@
 import { dbUpdateFailingMonitors } from '../db/queries.js';
 
-const update = async (rows) => {
-  const ids = rows.map(({ id }) => id);
-  if (ids.length !== 0) {
-    try {
-      await dbUpdateFailingMonitors(ids);
-    } catch (error) {
-      console.log(error);
-    }
+const updateFailed = async (monitors) => {
+  try {
+    const ids = monitors.map(({ id }) => id);
+    await dbUpdateFailingMonitors(ids);
+  } catch (error) {
+    console.log(error);
   }
 };
 
 export {
-  update,
+  updateFailed,
 };


### PR DESCRIPTION
##Questions
In `addPing`, I changed it to be passing the monitor we retrieve at the top of the function into the `dbUpdateNextAlert` function instead of another call in the `dbUpdateNextAlert` function like it was before. Not sure if there was any reason to retrieve the monitor twice? I thought maybe to reflect the changes made by dbAddPing and dbMonitorRecovery(now callled dbUpdateMonitorRecovered) but those fields seem unrelated and also are not being called with await anyway.


##Tested:
Adding a new monitor from UI

addPing
- Misspelling in SQL queries made by the function results in a database specific error message
- An incorrect endpoint_key that has no associated monitor results in an error message about that
- All calls to database from `addPing` need an `await` so that errors are handled properly and don’t cause race conditions (example of a race condition?)

Notify.js
- The dbGetOverdue function handles DB errors
- The async `update` function names changed a bit for clarity

