### PR TITLE
add delete monitor endpoint

### DIFF
--- a/requests/add_ping.rest
+++ b/requests/add_ping.rest
@@ -1,1 +1,1 @@
-POST http://localhost:3001/api/pings/hokS5ZI80q
+POST http://localhost:3001/api/pings/notamonitor

--- a/requests/delete_monitor.rest
+++ b/requests/delete_monitor.rest
@@ -1,0 +1,1 @@
+DELETE http://localhost:3001/api/monitors/2

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { dbGetAllMonitors, dbAddMonitor } from '../db/queries.js';
+import { dbGetAllMonitors, dbAddMonitor, dbDeleteMonitor } from '../db/queries.js';
 
 const validMonitor = (monitor) => {
   if (typeof monitor !== 'object') {
@@ -62,7 +62,27 @@ const addMonitor = async (req, res, next) => {
   }
 };
 
+const deleteMonitor = async (req, res, next) => {
+  try {
+    const id = req.params.id;
+    const deletedMonitor = await dbDeleteMonitor(id);
+
+    if (!deletedMonitor) {
+      const error = Error('Unable to find monitor associated with that id.');
+      error.statusCode = 404;
+      throw error;
+    }
+
+    console.log(deletedMonitor);
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};
+
 export {
   getMonitors,
   addMonitor,
+  deleteMonitor,
 };

--- a/src/controllers/monitor.js
+++ b/src/controllers/monitor.js
@@ -73,8 +73,6 @@ const deleteMonitor = async (req, res, next) => {
       throw error;
     }
 
-    console.log(deletedMonitor);
-
     res.status(204).send();
   } catch (error) {
     next(error);

--- a/src/controllers/ping.js
+++ b/src/controllers/ping.js
@@ -10,7 +10,9 @@ const addPing = async (req, res, next) => {
     const endpoint_key = req.params.endpoint_key;
     const monitor = await dbGetMonitorByEndpointKey(endpoint_key);
     if (!monitor) {
-      throw new Error('Unable to find monitor associated with that endpoint.');
+      const error = new Error('Unable to find monitor associated with that endpoint.');
+      error.statusCode = 404;
+      throw error;
     }
 
     await dbAddPing(monitor.id);

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -110,6 +110,18 @@ const dbUpdateMonitorRecovered = async (id) => {
   return await handleDatabaseQuery(UPDATE_RECOVERY, errorMessage, id);
 };
 
+const dbDeleteMonitor = async (id) => {
+  const DELETE_MONITOR = `
+    DELETE FROM monitor
+    WHERE id = $1
+    RETURNING *
+  `;
+  const errorMessage = 'Unable to delete monitor in database.';
+
+  const rows = await handleDatabaseQuery(DELETE_MONITOR, errorMessage, id);
+  return rows[0];
+};
+
 const dbAddPing = async (monitor_id) => {
   const ADD_PING = `
     INSERT INTO ping (monitor_id)
@@ -128,6 +140,7 @@ export {
   dbGetAllMonitors,
   dbUpdateNextAlert,
   dbAddMonitor,
+  dbDeleteMonitor,
   dbGetOverdue,
   dbAddPing,
 };

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,10 +1,11 @@
 import express from 'express';
 const router = express.Router();
-import { getMonitors, addMonitor } from '../controllers/monitor.js';
+import { getMonitors, addMonitor, deleteMonitor } from '../controllers/monitor.js';
 import { addPing } from '../controllers/ping.js';
 
 router.get('/monitors', getMonitors);
 router.post('/monitors', addMonitor);
+router.delete('/monitors/:id', deleteMonitor);
 
 router.post('/pings/:endpoint_key', addPing);
 

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -8,7 +8,7 @@ export const errorResponder = (error, req, res, next) => {
 
   let status;
   if (!error.statusCode) {
-    console.log('UNKNOWN: ', error);
+    console.log('Internal Server Error: ', error);
     status = 500;
     error.message = 'Internal Server Error';
   } else {

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -6,8 +6,18 @@ export const errorLogger = (error, req, res, next) => {
 export const errorResponder = (error, req, res, next) => {
   res.header('Content-Type', 'application/json');
 
-  const status = error.statusCode || 400;
-  res.status(status).send(error.message);
+  let status;
+  if (!error.statusCode) {
+    console.log('UNKNOWN: ', error);
+    status = 500;
+    error.message = 'Internal Server Error';
+  } else {
+    status = error.statusCode;
+  }
+
+  res.status(status).send({
+    message: error.message
+  });
 };
 
 export const invalidPathHandler = (req, res) => {


### PR DESCRIPTION
## Changes
- created `dbDeleteMonitor` query method: accepts the monitor id as a parameter and returns the deleted monitor (if there is one)
- added `deleteMonitor` method to the monitor controller: this calls the above database method and returns either an empty `204` response or a `404` with appropriate message
- changed the `api` router to route to the above method
- made a slight adjustment to how `errorResponder` works - potentially worth discussing
## Testing
Testing done with new rest extension request. Deleting existing monitor:
![image](https://github.com/Sundial-Inc/server/assets/102357760/78dce4a5-238a-4b86-ae08-107c689d12dd)
Deleting non-existent montior:
![image](https://github.com/Sundial-Inc/server/assets/102357760/04300733-9d0c-4c49-a6d6-e03711062455)
