### PR TITLE
Adding new attributes to ping and run tables

### DIFF
--- a/src/db/ddl/ping.sql
+++ b/src/db/ddl/ping.sql
@@ -5,7 +5,6 @@ CREATE TYPE events AS ENUM ('start', 'end');
 CREATE TABLE ping (
   id serial,
   run_token text NOT NULL,
-  monitor_id integer,
   send_time timestamp NOT NULL,
   event events NOT NULL,
   PRIMARY KEY (id),

--- a/src/db/ddl/ping.sql
+++ b/src/db/ddl/ping.sql
@@ -1,14 +1,14 @@
 DROP TABLE IF EXISTS ping;
 
-CREATE TYPE events AS ENUM ('started', 'completed');
+CREATE TYPE events AS ENUM ('start', 'end');
 
 CREATE TABLE ping (
   id serial,
-  -- run_id integer,
+  run_token text NOT NULL,
   monitor_id integer,
-  created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  -- event events NOT NULL,
+  send_time timestamp NOT NULL,
+  event events NOT NULL,
   PRIMARY KEY (id),
-  -- FOREIGN KEY (run_id) REFERENCES run(id) ON DELETE CASCADE
+  FOREIGN KEY (run_token) REFERENCES run(run_token) ON DELETE CASCADE
   FOREIGN KEY (monitor_id) REFERENCES monitor (id) ON DELETE CASCADE
 );

--- a/src/db/ddl/ping.sql
+++ b/src/db/ddl/ping.sql
@@ -10,5 +10,4 @@ CREATE TABLE ping (
   event events NOT NULL,
   PRIMARY KEY (id),
   FOREIGN KEY (run_token) REFERENCES run(run_token) ON DELETE CASCADE
-  FOREIGN KEY (monitor_id) REFERENCES monitor (id) ON DELETE CASCADE
 );

--- a/src/db/ddl/run.sql
+++ b/src/db/ddl/run.sql
@@ -4,10 +4,11 @@ CREATE TYPE states AS ENUM ('started', 'completed', 'failed');
 
 CREATE TABLE run (
   id serial,
+  run_token text NOT NULL,
   monitor_id integer NOT NULL,
   start_time integer NOT NULL,
   duration integer,
   state states NOT NULL,
-  PRIMARY KEY (id),
+  PRIMARY KEY (run_token),
   FOREIGN KEY (monitor_id) REFERENCES monitor(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
Added `run_token`, `event`, and `send_time` attributes to the `ping` table, per the Pings document. In addition, I added `run_token` to the `run` table and a FK constraint to the Pings table, in the case that a run gets deleted, so do the associated pings. 