### PR TITLE
Solo/ start and end pings in route and db

### DIFF
--- a/app/src/constants/runToken.js
+++ b/app/src/constants/runToken.js
@@ -1,0 +1,1 @@
+export const RUN_TOKEN_LENGTH = 10;

--- a/app/src/controllers/monitor.js
+++ b/app/src/controllers/monitor.js
@@ -40,10 +40,10 @@ const getMonitors = async (req, res, next) => {
 
 const addMonitor = async (req, res, next) => {
   const { ...monitorData } = req.body;
-  const endpoint_key = nanoid(10);
+  const endpointKey = nanoid(10);
 
   const newMonitorData = {
-    endpoint_key,
+    endpointKey,
     ...monitorData
   };
 

--- a/app/src/controllers/monitor.js
+++ b/app/src/controllers/monitor.js
@@ -10,7 +10,7 @@ const validMonitor = (monitor) => {
     return false;
   }
 
-  if (!monitor.endpoint_key || typeof monitor.endpoint_key !== 'string' || monitor.endpoint_key.length >= 25) {
+  if (!monitor.endpointKey || typeof monitor.endpointKey !== 'string' || monitor.endpointKey.length >= 25) {
     return false;
   }
 

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -3,19 +3,74 @@ import {
   dbUpdateMonitorRecovered,
   dbUpdateNextAlert,
   dbAddPing,
+  dbAddRun,
+  dbUpdateRun
 } from '../db/queries.js';
+
+/**
+ Notes: 
+  keep the endpoint_key in params for consistency
+
+  maybe add monitor id to pings for data collection later?
+  theres no convenient way to associate the pings to anything, except through finding out the runTokens of a specific monitor and then finding the pings associated with the run token which is maybe okay?
+
+  what format will startTime be in?
+
+  as of now an incoming ping does not notify if a job failed, only "started" and "completed" run states are set, "failed" is only possible if the run already exists and 
+
+ ping: sendTime, runToken, event
+
+ run: runTOken, monitorId, startTime, duration, state
+
+get monitor id 
+- verify it exists
+is ping a part of a run?
+  yes:
+    start of run?
+      startNewRun
+      - start new run (monitor id, run token, starttime, state='started')
+    end of run?
+      updateRun
+      - find by runtoken
+      - update duration to  now - starttime
+      - update state='completed' !!never failed as of now
+  no:
+    - nothing different
+  always:
+    addPing
+
+ */
+const startOfRun = (pingData) => {
+  return !!pingData && pingData.event === 'start';
+};
+
+const endOfRun = (pingData) => {
+  return !!pingData && pingData.event === 'end';
+};
+
+const validateMonitorExists = (monitor) => {
+  if (!monitor) {
+    const error = new Error('Unable to find monitor associated with that endpoint.');
+    error.statusCode = 404;
+    throw error;
+  }
+};
 
 const addPing = async (req, res, next) => {
   try {
     const endpoint_key = req.params.endpoint_key;
     const monitor = await dbGetMonitorByEndpointKey(endpoint_key);
-    if (!monitor) {
-      const error = new Error('Unable to find monitor associated with that endpoint.');
-      error.statusCode = 404;
-      throw error;
+    validateMonitorExists(monitor);
+
+    const pingData = req.body;
+    if (startOfRun(pingData)) {
+      await dbAddRun(pingData, monitor.id);
+    }
+    if (endOfRun(pingData)) {
+      await dbUpdateRun(pingData);
     }
 
-    await dbAddPing(monitor.id);
+    await dbAddPing(pingData, monitor.id);
 
     if (monitor.failing) {
       await dbUpdateMonitorRecovered(monitor.id);

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -25,7 +25,7 @@ const eventToState = {
 const formatRunData = (id, event, body ) => {
   return {
     monitorId: id,
-    time: body.time || Date.now(),
+    time: body.time || new Date(),
     runToken: body.runToken || null,
     state: eventToState[event],
   };
@@ -35,7 +35,7 @@ const formatRunData = (id, event, body ) => {
 ping format:
   endpointKey path param
   event query param
-  { time: Date.now(), runToken: string }
+  { time: new Date(), runToken: string }
 */
 const addPing = async (req, res, next) => {
   try {

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -16,7 +16,7 @@ const endOfRun = (pingData) => {
   return !!pingData && pingData.event === 'end';
 };
 
-const validateMonitorExists = (monitor) => {
+const handleMissingMonitor = (monitor) => {
   if (!monitor) {
     const error = new Error('Unable to find monitor associated with that endpoint.');
     error.statusCode = 404;
@@ -28,7 +28,7 @@ const addPing = async (req, res, next) => {
   try {
     const endpoint_key = req.params.endpoint_key;
     const monitor = await dbGetMonitorByEndpointKey(endpoint_key);
-    validateMonitorExists(monitor);
+    handleMissingMonitor(monitor);
 
     const pingData = req.body;
     console.log(pingData);
@@ -42,6 +42,7 @@ const addPing = async (req, res, next) => {
       const run = await dbUpdateRun(pingData);
       console.log(run);
     } else {
+      console.log('single');
       pingData.event = 'single';
       pingData.runToken = generateRunToken();
       pingData.sendTime = new Date();

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -1,7 +1,7 @@
 import {
   dbGetMonitorByEndpointKey,
-  dbUpdateMonitorRecovered,
-  dbUpdateNextAlert,
+  // dbUpdateMonitorRecovered,
+  // dbUpdateNextAlert,
   dbGetRunByRunToken,
   dbAddRun,
   dbUpdateRun,
@@ -14,14 +14,6 @@ const handleMissingMonitor = (monitor) => {
     throw error;
   }
 };
-
-
-/*
-ping
-  endpointKey path param
-  event query param
-  { time: Date.now(), runToken: string }
-*/
 
 const eventToState = {
   'solo': 'solo_completed',
@@ -39,6 +31,12 @@ const formatRunData = (id, event, body ) => {
   };
 };
 
+/*
+ping format:
+  endpointKey path param
+  event query param
+  { time: Date.now(), runToken: string }
+*/
 const addPing = async (req, res, next) => {
   try {
     const endpointKey = req.params.endpoint_key;
@@ -47,15 +45,18 @@ const addPing = async (req, res, next) => {
     const event = req.query.event;
     const runData = formatRunData(monitor.id, event, req.body);
 
+    console.log(runData)
     if (event === 'solo') {
       // alter solo job queue
-      await dbAddRun(runData);
+      const res = await dbAddRun(runData);
+      console.log(res)
     }
 
     if (event === 'starting') {
       // alter starting job queue
       // alter ending job queue
-      await dbAddRun(runData);
+      const res = await dbAddRun(runData);
+      console.log(res)
     }
 
     if (event === 'failing' || event === 'ending') {
@@ -63,10 +64,14 @@ const addPing = async (req, res, next) => {
 
       if (existingRun) {
         // alter end job queue
-        await dbUpdateRun(existingRun.id, runData);
+        const res = await dbUpdateRun(existingRun.id, runData);
+        console.log(res)
       } else {
         runData.state = 'no_start';
-        await dbAddRun(runData);
+        console.log(runData)
+
+        const res = await dbAddRun(runData);
+        console.log(res)
       }
     }
 

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -57,7 +57,7 @@ const dbGetAllMonitors = async () => {
 
 const dbAddMonitor = async ( monitor ) => {
   const columns = ['endpoint_key', 'schedule'];
-  const values = [monitor.endpoint_key, monitor.schedule];
+  const values = [monitor.endpointKey, monitor.schedule];
 
   if (monitor.name) {
     columns.push('name');
@@ -71,7 +71,7 @@ const dbAddMonitor = async ( monitor ) => {
 
   if (monitor.grace_period) {
     columns.push('grace_period');
-    values.push(monitor.grace_period);
+    values.push(monitor.gracePeriod);
   }
 
   const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');

--- a/app/src/jobs/notify.js
+++ b/app/src/jobs/notify.js
@@ -2,11 +2,12 @@ import { dbGetOverdue } from '../db/queries.js';
 import { updateFailed } from '../utils/notificationUpdates.js';
 (async () => {
   try {
-    const overdueMonitors = await dbGetOverdue();
-    console.log(overdueMonitors);
-    if (overdueMonitors.length > 0) {
-      await updateFailed(overdueMonitors);
-    }
+    // const overdueMonitors = await dbGetOverdue();
+    // console.log(overdueMonitors);
+    // if (overdueMonitors.length > 0) {
+      // await updateFailed(overdueMonitors);
+    // }
+    console.log('hey from our old Bree notification system');
   } catch (error) {
     console.error('Failed retrieving overdue job from database.', error);
   }

--- a/app/src/notifications/handleNotifications.js
+++ b/app/src/notifications/handleNotifications.js
@@ -4,12 +4,13 @@ import formatNotification from './formatNotification.js';
 
 (async () => {
   try {
-    const overdueMonitors = await dbGetOverdue();
-    console.log(overdueMonitors);
-    await dbUpdateFailingMonitors(overdueMonitors.map(({ id }) => id));
-    await Promise.all(overdueMonitors.map(monitor => {
-      return slack.sendNotification(formatNotification(monitor));
-    }));
+    // const overdueMonitors = await dbGetOverdue();
+    // console.log(overdueMonitors);
+    // await dbUpdateFailingMonitors(overdueMonitors.map(({ id }) => id));
+    // await Promise.all(overdueMonitors.map(monitor => {
+    //   return slack.sendNotification(formatNotification(monitor));
+    // }));
+    console.log("hey again from old notification system");
   } catch (error) {
     console.log(error);
   }

--- a/app/src/notifications/providers/slack.js
+++ b/app/src/notifications/providers/slack.js
@@ -3,9 +3,11 @@ import axios from 'axios';
 
 const slack = {
   async sendNotification(text) {
-    await axios.post(process.env.SLACK_WEBHOOK_URL, {
-      text
-    });
+    if (process.env.SLACK_WEBHOOK_URL) {
+      await axios.post(process.env.SLACK_WEBHOOK_URL, {
+        text
+      });
+    }
   },
 };
 

--- a/app/src/utils/generateRunToken.js
+++ b/app/src/utils/generateRunToken.js
@@ -1,0 +1,9 @@
+import crypto from 'crypto';
+import { RUN_TOKEN_LENGTH } from '../constants/runToken.js';
+
+const generateRunToken = () => {
+  const bytes = crypto.randomBytes(RUN_TOKEN_LENGTH / 2);
+  return bytes.toString('hex');
+};
+
+export default generateRunToken;

--- a/database/init.sql
+++ b/database/init.sql
@@ -21,10 +21,10 @@ CREATE TYPE states AS ENUM ('started', 'completed', 'failed');
 
 CREATE TABLE run (
   id serial,
-  run_token text NOT NULL,
+  run_token text NOT NULL UNIQUE,
   monitor_id integer NOT NULL,
-  start_time integer NOT NULL,
-  duration integer,
+  start_time timestamp,
+  duration interval,
   state states NOT NULL,
   PRIMARY KEY (run_token),
   FOREIGN KEY (monitor_id) REFERENCES monitor(id) ON DELETE CASCADE
@@ -32,7 +32,7 @@ CREATE TABLE run (
 
 DROP TABLE IF EXISTS ping;
 
-CREATE TYPE events AS ENUM ('start', 'end');
+CREATE TYPE events AS ENUM ('start', 'end', 'single');
 
 CREATE TABLE ping (
   id serial,

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,5 +1,7 @@
 DROP TABLE IF EXISTS monitor;
 
+CREATE TYPE states AS ENUM ('active', 'pending', 'failed');
+
 CREATE TABLE monitor (
   id serial,
   endpoint_key text UNIQUE NOT NULL,
@@ -7,7 +9,7 @@ CREATE TABLE monitor (
   schedule text NOT NULL,
   command text,
   active boolean NOT NULL DEFAULT true,
-  failing boolean NOT NULL DEFAULT false,
+  state states NOT NULL DEFAULT 'pending',
   next_alert timestamp,
   realert_interval integer DEFAULT 480, -- mins
   created_at timestamp DEFAULT CURRENT_TIMESTAMP,
@@ -23,7 +25,7 @@ CREATE TABLE run (
   id serial,
   run_token text NOT NULL UNIQUE,
   monitor_id integer NOT NULL,
-  start_time timestamp,
+  time timestamp,
   duration interval,
   state states NOT NULL,
   PRIMARY KEY (run_token),
@@ -32,7 +34,7 @@ CREATE TABLE run (
 
 DROP TABLE IF EXISTS ping;
 
-CREATE TYPE events AS ENUM ('start', 'end', 'single');
+CREATE TYPE events AS ENUM ('start', 'end');
 
 CREATE TABLE ping (
   id serial,

--- a/ui/src/components/AddMonitorForm.jsx
+++ b/ui/src/components/AddMonitorForm.jsx
@@ -25,7 +25,7 @@ const AddMonitorForm = ({ onSubmitForm, onBack, addErrorMessage }) => {
       schedule: schedule,
       name: name || undefined,
       command: command || undefined,
-      grace_period: notifyTime || undefined,
+      gracePeriod: notifyTime || undefined,
     };
 
     return onSubmitForm(monitorData);

--- a/ui/src/components/Monitor.jsx
+++ b/ui/src/components/Monitor.jsx
@@ -20,7 +20,7 @@ export const Monitor = ({ monitor, count, onDelete }) => {
                 <Typography variant="subtitle1">Wrapper: {generateCurl(monitor)}</Typography>
                 <Typography variant="subtitle1">Schedule: {monitor.schedule}</Typography>
                 <Typography variant="subtitle1">Next Expected At: {nextRun(monitor.schedule)}</Typography>
-                <Typography variant="subtitle1">Status: {monitor.failing ? 'Failed' : 'Running'}</Typography>
+                <Typography variant="subtitle1">Status: {monitor.state}</Typography>
                 <DeleteButton onDelete={() => onDelete(monitor.id)} />
               </div>
             }


### PR DESCRIPTION
Just the skeleton for the different types of pings initiating a run logic, each route still needs to alter the actual job queue.

I kept the console logs in intentionally so we could continue testing until the entire pings system is up.

Also commented out previous notification db calls for now, assuming we will delete them soon.