### PR TITLE
Remove references to Ping table (DB)

### DIFF
--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -2,7 +2,6 @@ import {
   dbGetMonitorByEndpointKey,
   dbUpdateMonitorRecovered,
   dbUpdateNextAlert,
-  dbAddPing,
 } from '../db/queries.js';
 
 const addPing = async (req, res, next) => {
@@ -14,8 +13,6 @@ const addPing = async (req, res, next) => {
       error.statusCode = 404;
       throw error;
     }
-
-    await dbAddPing(monitor.id);
 
     if (monitor.failing) {
       await dbUpdateMonitorRecovered(monitor.id);

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -126,17 +126,6 @@ const dbDeleteMonitor = async (id) => {
   return rows[0];
 };
 
-const dbAddPing = async (monitor_id) => {
-  const ADD_PING = `
-    INSERT INTO ping (monitor_id)
-    VALUES ($1)
-    RETURNING *
-  `;
-  const errorMessage = 'Unable to add ping to database.';
-
-  return await handleDatabaseQuery(ADD_PING, errorMessage, monitor_id);
-};
-
 export {
   dbUpdateFailingMonitors,
   dbUpdateMonitorRecovered,
@@ -146,5 +135,4 @@ export {
   dbAddMonitor,
   dbDeleteMonitor,
   dbGetOverdue,
-  dbAddPing,
 };


### PR DESCRIPTION
Since we've deleted the Ping table, I just went ahead and removed the `dbAddPing` query (which was specifically for inserting to the Ping table), along with any calls to that query.