### PR TITLE
Solo ping job functionality

### DIFF
--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -1,11 +1,15 @@
 import {
   dbGetMonitorByEndpointKey,
+  dbUpdateMonitorType,
   // dbUpdateMonitorRecovered,
   // dbUpdateNextAlert,
   dbGetRunByRunToken,
   dbAddRun,
   dbUpdateRun,
 } from '../db/queries.js';
+
+import MissedPingsMq from '../db/MissedPingsMq.js';
+import { nextScheduledRun } from '../utils/cronParser.js';
 
 const handleMissingMonitor = (monitor) => {
   if (!monitor) {
@@ -22,7 +26,7 @@ const eventToState = {
   'ending': 'completed',
 };
 
-const formatRunData = (id, event, body ) => {
+const formatRunData = (id, event, body) => {
   return {
     monitorId: id,
     time: body.time || new Date(),
@@ -41,9 +45,16 @@ const addPing = async (req, res, next) => {
 
     console.log(runData)
     if (event === 'solo') {
-      // alter solo job queue
-      const res = await dbAddRun(runData);
-      console.log(res)
+      const delay = nextScheduledRun(monitor.schedule) + monitor.grace_period + monitor.tolerable_runtime;
+      if (monitor.type !== 'solo') {
+        await dbUpdateMonitorType('solo', id);
+        MissedPingsMq.removeStartJob(monitor.id);
+      } else {
+        MissedPingsMq.removeSoloJob(monitor.id);
+      }
+
+      await dbAddRun(runData);
+      MissedPingsMq.addSoloJob({monitorId: id}, delay);
     }
 
     if (event === 'starting') {

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -45,16 +45,17 @@ const addPing = async (req, res, next) => {
 
     console.log(runData)
     if (event === 'solo') {
+
       const delay = nextScheduledRun(monitor.schedule) + monitor.grace_period + monitor.tolerable_runtime;
       if (monitor.type !== 'solo') {
         await dbUpdateMonitorType('solo', id);
-        MissedPingsMq.removeStartJob(monitor.id);
+        await MissedPingsMq.removeStartJob(monitor.id);
       } else {
-        MissedPingsMq.removeSoloJob(monitor.id);
+        await MissedPingsMq.removeSoloJob(monitor.id);
       }
 
       await dbAddRun(runData);
-      MissedPingsMq.addSoloJob({monitorId: id}, delay);
+      await MissedPingsMq.addSoloJob({monitorId: id}, delay);
     }
 
     if (event === 'starting') {

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -115,6 +115,18 @@ const dbUpdateMonitorRecovered = async (id) => {
   return await handleDatabaseQuery(UPDATE_RECOVERY, errorMessage, id);
 };
 
+const dbUpdateMonitorType = async (type, id) => {
+  const UPDATE_TYPE = `
+    UPDATE monitor
+    SET type = $1
+    WHERE monitor.id = $2
+    RETURNING *
+  `;
+  const errorMessage = 'Unable to update monitor type in database.';
+
+  return await handleDatabaseQuery(UPDATE_TYPE, errorMessage, type, id);
+}
+
 const dbDeleteMonitor = async (id) => {
   const DELETE_MONITOR = `
     DELETE FROM monitor

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -181,6 +181,7 @@ export {
   dbGetAllMonitors,
   dbUpdateNextAlert,
   dbAddMonitor,
+  dbUpdateMonitorType,
   dbDeleteMonitor,
   dbGetOverdue,
   dbAddRun,


### PR DESCRIPTION
Added the functionality for solo pings that:

-  Checks if monitor type is “solo”
- if yes, associated job from solo queue is removed
- if no, monitor type is updated to “solo” and associated job is removed from start queue
- creates new job in solo queue

For updating the monitor type, I added the `dbUpdateMonitorType` query.