### PR TITLE
Populate start solo on startup

### DIFF
--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -9,7 +9,6 @@ import {
 } from '../db/queries.js';
 
 import MissedPingsMq from '../db/MissedPingsMq.js';
-import { nextScheduledRun } from '../utils/cronParser.js';
 import { calculateDelay } from '../utils/calculateDelay.js';
 
 const handleMissingMonitor = (monitor) => {
@@ -54,7 +53,7 @@ const addPing = async (req, res, next) => {
       }
 
       await dbAddRun(runData);
-      await MissedPingsMq.addSoloJob({monitorId: monitor.id}, calculateDelay(monitor));
+      await MissedPingsMq.addSoloJob({ monitorId: monitor.id }, calculateDelay(monitor));
     }
 
     if (event === 'starting') {

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -10,6 +10,7 @@ import {
 
 import MissedPingsMq from '../db/MissedPingsMq.js';
 import { nextScheduledRun } from '../utils/cronParser.js';
+import { calculateDelay } from '../utils/calculateDelay.js';
 
 const handleMissingMonitor = (monitor) => {
   if (!monitor) {
@@ -44,12 +45,6 @@ const addPing = async (req, res, next) => {
     const runData = formatRunData(monitor.id, event, req.body);
 
     if (event === 'solo') {
-      const calculateDelay = (monitor) => {
-        const runTime = nextScheduledRun(monitor.schedule)._date.ts +
-          ((monitor.grace_period + monitor.tolerable_runtime) * 1000); // milliseconds from epoch
-      
-        return (runTime - Date.now()) / 1000; // delay in seconds
-      };
       if (monitor.type !== 'solo') {
         await dbUpdateMonitorType('solo', id);
         await MissedPingsMq.removeStartJob(monitor.id);
@@ -58,7 +53,7 @@ const addPing = async (req, res, next) => {
       }
 
       await dbAddRun(runData);
-      await MissedPingsMq.addSoloJob({monitorId: monitor.id}, calculateDelay);
+      await MissedPingsMq.addSoloJob({monitorId: monitor.id}, calculateDelay(monitor));
     }
 
     if (event === 'starting') {

--- a/app/src/db/MissedPingsMq.js
+++ b/app/src/db/MissedPingsMq.js
@@ -34,31 +34,18 @@ const MissedPingsMq = {
     console.log('PgBoss initialized and ready for use.');
   },
 
-  async startWorker(job) {
-    console.log(job);
-  },
-
-  async endWorker(job) {
-    console.log(job);
-  },
-
-  async soloWorker(job) {
-    console.log(job);
-  },
-
   async populateStartSoloQueues() {
     await this.boss.deleteAllQueues();
     const monitors = await dbGetAllMonitors();
 
-    const monitorJobs = monitors.reduce((arr, monitor )=> {
-      if (monitor.type == 'dual') {
-        arr.push(MissedPingsMq.addStartJob({monitorId: monitor.id}, calculateDelay(monitor)));
+    const monitorJobs = monitors.reduce((arr, monitor ) => {
+      if (monitor.type === 'dual') {
+        arr.push(MissedPingsMq.addStartJob({ monitorId: monitor.id }, calculateDelay(monitor)));
       } else {
-        arr.push(MissedPingsMq.addSoloJob({monitorId: monitor.id}, calculateDelay(monitor)));
+        arr.push(MissedPingsMq.addSoloJob({ monitorId: monitor.id }, calculateDelay(monitor)));
       }
       return arr;
     }, []);
-
 
     Promise.allSettled(monitorJobs);
   },

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -8,9 +8,5 @@ app.listen(port, async () => {
   console.log(`Sundial app server listening on port ${port}`);
   setupJobs();
   await MissedPingsMq.init();
-
-  // MQ tests please delete
-  MissedPingsMq.addStartJob({ monitorId: 12 }, 5);
-  MissedPingsMq.addEndJob({ monitorId: 15 }, 10);
-  MissedPingsMq.addSoloJob({ monitorId: 20 }, 15);
+  await MissedPingsMq.populateStartSoloQueues();
 });

--- a/app/src/utils/calculateDelay.js
+++ b/app/src/utils/calculateDelay.js
@@ -1,4 +1,6 @@
-      const calculateDelay = (monitor) => {
+      import { nextScheduledRun } from "./cronParser.js";
+
+      export const calculateDelay = (monitor) => {
         const runTime = nextScheduledRun(monitor.schedule)._date.ts +
           ((monitor.grace_period + monitor.tolerable_runtime) * 1000); // milliseconds from epoch
       

--- a/app/src/utils/calculateDelay.js
+++ b/app/src/utils/calculateDelay.js
@@ -1,0 +1,6 @@
+      const calculateDelay = (monitor) => {
+        const runTime = nextScheduledRun(monitor.schedule)._date.ts +
+          ((monitor.grace_period + monitor.tolerable_runtime) * 1000); // milliseconds from epoch
+      
+        return (runTime - Date.now()) / 1000; // delay in seconds
+      };


### PR DESCRIPTION
This seems to work fine, based on the monitors currently in my db (I have two dual monitors, one solo). Some questions I had before making a full PR:

- I added `populateStartSoloQueues` as a method to `MissedPingsMq`, separate from `init`, since that seemed mainly about starting up pg-boss and the associated workers. Should it be included there though?
- I'm calling that same method in `index.js`, just after the `init` call. This feels like it might be bad practice though, since it is part of the general init to that class. Not sure where else would be appropriate, however.
- The `startJobs` and `soloJobs` queues are initialized fine....but because they're arrays and there's no guarantees that my monitors start with ids at 1, we end up creating a bunch of empty array slots because we insert into the array at the id. This feels...not good. Should we be making these objects? (can't remember if that was what Jacob already suggested) See image below 👇 

I also shoved `calculateDelay` into a separate function in the utils folder.

![Screenshot 2023-10-26 at 4 10 43 PM](https://github.com/Sundial-Inc/server/assets/10123446/56c313bc-edbd-4947-bbce-ef00614d7148)
