### PR TITLE
Adding monitor type for createMonitor calls from the UI

### DIFF
--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -67,8 +67,8 @@ const dbGetAllMonitors = async () => {
 };
 
 const dbAddMonitor = async ( monitor ) => {
-  const columns = ['endpoint_key', 'schedule'];
-  const values = [monitor.endpointKey, monitor.schedule];
+  const columns = ['endpoint_key', 'schedule', 'type'];
+  const values = [monitor.endpointKey, monitor.schedule, monitor.type];
 
   if (monitor.name) {
     columns.push('name');

--- a/ui/src/components/AddMonitorForm.jsx
+++ b/ui/src/components/AddMonitorForm.jsx
@@ -26,6 +26,7 @@ const AddMonitorForm = ({ onSubmitForm, onBack, addErrorMessage }) => {
       name: name || undefined,
       command: command || undefined,
       gracePeriod: gracePeriod || undefined,
+      type: 'solo'
     };
 
     return onSubmitForm(monitorData);


### PR DESCRIPTION
We aren't able to get rid of the types in the `monitor` table because we need some way to add them to the appropriate queues any time they are added and on startup. I know we said that we didn't need it for removing because we can call both, but I don't think we can do that for adding/populating the queues. (Unless I missed it and the idea was to only have one start queue.)

Here, I've added the type 'solo' to the call made in the UI and have adjusted the 'dbAddMonitor' query to expect a type.

The assumption I'm working with is that calls made to dbAddMonitor from the UI are going to be solo pings for now, while those made from the CLI (from running `sundial discover` are going to be 'dual'). I have a PR in the CLI repo for that change.

Feel free to correct me if I'm wrong!