### PR TITLE
Adding 'solo_missed' status to runs

### DIFF
--- a/ui/src/components/Run.jsx
+++ b/ui/src/components/Run.jsx
@@ -18,7 +18,7 @@ const Run = ({ run }) => {
   };
 
   let colorByState = okay;
-  if (run.state === 'failed' || run.state === 'missed') {
+  if (run.state === 'failed' || run.state === 'missed' || run.state === 'solo_missed') {
     colorByState = alert;
   } else if (run.state === 'unresolved' || run.state === 'no_start') {
     colorByState = warning;
@@ -33,6 +33,7 @@ const Run = ({ run }) => {
       no_start: "Only an end ping was received",
       solo_completed: "The job ran",
       missed: "The job did not run",
+      solo_missed: "The job did not run",
     };
   
     return stateMap[state]


### PR DESCRIPTION
Just updated it so that runs can also display if they have a `solo_missed` status.

![Screenshot 2023-10-27 at 3 23 30 PM](https://github.com/Sundial-Inc/server/assets/10123446/5bf62c4c-b797-4a25-8678-e36f981763a2)
