### PR TITLE
Server Sent Events

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,8 +1,9 @@
 import express from 'express';
 import cors from 'cors';
-import router from './routes/api.js';
+import api from './routes/api.js';
 import home from './routes/home.js';
 import error from './routes/error.js';
+import sse from './routes/sse.js';
 import { errorLogger, errorResponder, invalidPathHandler } from './utils/errorHandler.js';
 
 const app = express();
@@ -11,8 +12,9 @@ app.use(cors());
 app.use(express.json());
 
 app.use('/', home);
-app.use('/api', router);
-app.use(error);
+app.use('/api', api);
+app.use('/error', error);
+app.use('/sse', sse);
 
 app.use(errorLogger);
 app.use(errorResponder);

--- a/app/src/controllers/ping.js
+++ b/app/src/controllers/ping.js
@@ -12,6 +12,7 @@ import {
 import MissedPingsMq from '../db/MissedPingsMq.js';
 import { calculateStartDelay, calculateSoloDelay, calculateEndDelay } from '../utils/calculateDelays.js';
 import handleNotifications from '../notifications/handleNotifications.js';
+import { sendNewRun, sendUpdatedMonitor, sendUpdatedRun } from './sse.js';
 
 const handleMissingMonitor = (monitor) => {
   if (!monitor) {
@@ -55,11 +56,13 @@ const addPing = async (req, res, next) => {
       const delay = calculateSoloDelay(monitor);
       await MissedPingsMq.addSoloJob({ monitorId: monitor.id }, delay);
 
-      await dbAddRun(runData);
+      const newRun = await dbAddRun(runData);
+      sendNewRun(newRun);
 
       if (monitor.failing) {
-        await dbUpdateMonitorRecovered(monitor.id);
-        handleNotifications(monitor, runData);
+        const updatedMonitor = await dbUpdateMonitorRecovered(monitor.id);
+        sendUpdatedMonitor(updatedMonitor);
+        handleNotifications(updatedMonitor, runData);
       }
     }
 
@@ -80,13 +83,15 @@ const addPing = async (req, res, next) => {
         } else {
           runData.state = 'failed';
         }
-        const run = await dbUpdateNoStartRun(runData);
-        console.log('updated existing: ', run);
+        const updatedRun = await dbUpdateNoStartRun(runData);
+        sendUpdatedRun(updatedRun);
+        console.log('updated existing: ', updatedRun);
       } else {
         const endDelay = calculateEndDelay(monitor);
         await MissedPingsMq.addEndJob({ runToken: runData.runToken, monitorId: monitor.id }, endDelay);
-        const run = await dbAddRun(runData);
-        console.log('created new:', run);
+        const newRun = await dbAddRun(runData);
+        sendNewRun(newRun);
+        console.log('created new:', newRun);
       }
     }
 
@@ -94,18 +99,21 @@ const addPing = async (req, res, next) => {
       const existingRun = await dbGetRunByRunToken(runData.runToken);
       if (existingRun) {
         await MissedPingsMq.removeEndJob(runData.runToken);
-        const run = await dbUpdateStartedRun(runData);
-        console.log('End updated: ', run);
+        const updatedRun = await dbUpdateStartedRun(runData);
+        sendUpdatedRun(updatedRun);
+        console.log('End updated: ', updatedRun);
       } else {
         runData.state = 'no_start';
-        const run = await dbAddRun(runData);
-        console.log('End created: ', run);
+        const newRun = await dbAddRun(runData);
+        sendNewRun(newRun);
+        console.log('End created: ', newRun);
       }
 
       if (monitor.failing) {
         console.log('In ending ping monitor is no longer failing');
-        await dbUpdateMonitorRecovered(monitor.id);
-        handleNotifications(monitor, runData);
+        const updatedMonitor = await dbUpdateMonitorRecovered(monitor.id);
+        sendUpdatedMonitor(updatedMonitor);
+        handleNotifications(updatedMonitor, runData);
       }
     }
 
@@ -113,19 +121,22 @@ const addPing = async (req, res, next) => {
       const existingRun = await dbGetRunByRunToken(runData.runToken);
       if (existingRun) {
         await MissedPingsMq.removeEndJob(runData.runToken);
-        await dbUpdateStartedRun(runData);
+        const updatedRun = await dbUpdateStartedRun(runData);
+        sendUpdatedRun(updatedRun);
       } else {
-        await dbAddRun(runData);
+        const newRun = await dbAddRun(runData);
+        sendNewRun(newRun);
       }
 
       if (!monitor.failing) {
-        await dbUpdateMonitorFailing(monitor.id);
+        const updatedMonitor = await dbUpdateMonitorFailing(monitor.id);
+        sendUpdatedMonitor(updatedMonitor);
         console.log('In failing ping monitor is now failing');
-        handleNotifications(monitor, runData);
+        handleNotifications(updatedMonitor, runData);
       }
     }
 
-    console.log("Initial run data:", runData);
+    console.log('Initial run data:', runData);
     res.status(200).send();
   } catch(error) {
     next(error);

--- a/app/src/controllers/sse.js
+++ b/app/src/controllers/sse.js
@@ -25,10 +25,6 @@ const getSse = (request, response) => {
   });
 };
 
-const sendSse = (data) => {
-  clients.forEach(client => client.response.write(`data: ${JSON.stringify(data)}\n\n`));
-};
-
 const sendMessage = (message) => {
   clients.forEach(client => client.response.write(message));
 };
@@ -62,7 +58,6 @@ const sendUpdatedRun = (run) => {
 
 export {
   getSse,
-  sendSse,
   sendUpdatedMonitor,
   sendNewRun,
   sendUpdatedRun,

--- a/app/src/controllers/sse.js
+++ b/app/src/controllers/sse.js
@@ -1,0 +1,69 @@
+let clients = [];
+
+const getSse = (request, response) => {
+  const headers = {
+    'Content-Type': 'text/event-stream',
+    'Connection': 'keep-alive',
+    'Cache-Control': 'no-cache',
+  };
+  response.writeHead(200, headers);
+
+  const clientId = Date.now();
+
+  const newClient = {
+    id: clientId,
+    response,
+  };
+
+  clients.push(newClient);
+  console.log(`New sse connection: ${clientId}`);
+  console.log(clients);
+
+  request.on('close', () => {
+    console.log(`${clientId}: Sse connection closed`);
+    clients = clients.filter(client => client.id !== clientId);
+  });
+};
+
+const sendSse = (data) => {
+  clients.forEach(client => client.response.write(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+const sendMessage = (message) => {
+  clients.forEach(client => client.response.write(message));
+};
+
+const sendUpdatedMonitor = (monitor) => {
+  const message =
+    'event: updatedMonitor\n' +
+    `data: ${JSON.stringify(monitor)}` +
+    '\n\n';
+
+  sendMessage(message);
+};
+
+const sendNewRun = (run) => {
+  const message =
+    'event: newRun\n' +
+    `data: ${JSON.stringify(run)}` +
+    '\n\n';
+
+  sendMessage(message);
+};
+
+const sendUpdatedRun = (run) => {
+  const message =
+    'event: updatedRun\n' +
+    `data: ${JSON.stringify(run)}` +
+    '\n\n';
+
+  sendMessage(message);
+};
+
+export {
+  getSse,
+  sendSse,
+  sendUpdatedMonitor,
+  sendNewRun,
+  sendUpdatedRun,
+};

--- a/app/src/routes/error.js
+++ b/app/src/routes/error.js
@@ -1,6 +1,6 @@
 import express from 'express';
 const router = express.Router();
 
-export default router.get('/error', (req, res) => {
+export default router.get('/', (req, res) => {
   res.status(404).send('The URL you are trying to reach does not exist.');
 });

--- a/app/src/routes/sse.js
+++ b/app/src/routes/sse.js
@@ -1,0 +1,7 @@
+import express from 'express';
+const router = express.Router();
+import { getSse } from '../controllers/sse.js';
+
+router.get('/', getSse);
+
+export default router;

--- a/app/src/workers/endWorker.js
+++ b/app/src/workers/endWorker.js
@@ -1,3 +1,4 @@
+import { sendUpdatedMonitor, sendUpdatedRun } from '../controllers/sse.js';
 import { dbGetMonitorById, dbUpdateMonitorFailing, dbUpdateStartedRun } from '../db/queries.js';
 import handleNotifications from '../notifications/handleNotifications.js';
 
@@ -21,11 +22,13 @@ const endWorker = async (job) => {
     };
 
     if (!monitor.failing) {
-      await dbUpdateMonitorFailing(monitor.id);
-      handleNotifications(monitor, runData);
+      const updatedMonitor = await dbUpdateMonitorFailing(monitor.id);
+      sendUpdatedMonitor(updatedMonitor);
+      handleNotifications(updatedMonitor, runData);
     }
 
-    await dbUpdateStartedRun(runData);
+    const updatedRun = await dbUpdateStartedRun(runData);
+    sendUpdatedRun(updatedRun);
   } catch (error) {
     console.error(error);
   }

--- a/app/src/workers/soloWorker.js
+++ b/app/src/workers/soloWorker.js
@@ -2,6 +2,7 @@ import MissedPingsMq from '../db/MissedPingsMq.js';
 import { dbGetMonitorById, dbAddRun, dbUpdateMonitorFailing } from '../db/queries.js';
 import { calculateSoloDelay } from '../utils/calculateDelays.js';
 import handleNotifications from '../notifications/handleNotifications.js';
+import { sendNewRun, sendUpdatedMonitor } from '../controllers/sse.js';
 
 const handleMissingMonitor = (monitor) => {
   if (!monitor) {
@@ -24,11 +25,13 @@ const startWorker = async (job) => {
     };
 
     if (!monitor.failing) {
-      await dbUpdateMonitorFailing(monitor.id);
-      handleNotifications(monitor, runData);
+      const updatedMonitor = await dbUpdateMonitorFailing(monitor.id);
+      sendUpdatedMonitor(updatedMonitor);
+      handleNotifications(updatedMonitor, runData);
     }
 
-    await dbAddRun(runData);
+    const newRun = await dbAddRun(runData);
+    sendNewRun(newRun);
     await MissedPingsMq.addSoloJob({ monitorId: monitor.id }, calculateSoloDelay(monitor));
   } catch (error) {
     console.error(error);

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -99,7 +99,6 @@ const App = () => {
         }));
         
         setRunData(runData => {
-          console.log(runData);
           if (runData.monitor && runData.monitor.id === updatedMonitor.id) {
             return {
               monitor: updatedMonitor,
@@ -116,7 +115,6 @@ const App = () => {
         console.log('New run:', newRun);
 
         setRunData(runData => {
-          console.log(runData);
           if (runData.monitor && runData.monitor.id === newRun.monitor_id && !runData.runs.find(run => run.id === newRun.id)) {
             return {
               monitor: runData.monitor,
@@ -133,7 +131,6 @@ const App = () => {
         console.log('Updated run:', updatedRun);
   
         setRunData(runData => {
-          console.log(runData);
           if (runData.monitor && runData.monitor.id === updatedRun.monitor_id) {
             return {
               monitor: runData.monitor,

--- a/ui/src/constants/routes.js
+++ b/ui/src/constants/routes.js
@@ -5,3 +5,4 @@ export const GET_RUNS = '/api/monitors/';
 export const CREATE_MONITOR = '/api/monitors';
 export const DELETE_MONITOR = '/api/monitors/';
 export const CREATE_PING = '/api/pings';
+export const GET_SSE = '/sse';

--- a/ui/src/services/sse.js
+++ b/ui/src/services/sse.js
@@ -1,0 +1,8 @@
+import {
+  BASE_URL,
+  GET_SSE,
+} from '../constants/routes';
+
+export const getSse = () => {
+  return new EventSource(BASE_URL + GET_SSE);
+};


### PR DESCRIPTION
# Changes
## Backend
### SSE Controller
- Handles GET requests made to `/sse`
- Sends a `200` response with headers set to indicate an SSE connection
- Stores new connections in memory 
- Removes connections from store when connections close
- Provides `sendUpdatedMonitor`, `sendNewRun` and `sendUpdatedRun` methods which can be used to send events to all open connections. Each of these methods uses a different event type when sending data
### Pings Controller and Workers
- Adjusted these files to make use of the `send` methods provided by the `sse` controller
- Whenever a monitors `failing` attribute is updated, a run is created or a run is updated in these files an appropriate event is sent along with the created/updated data
## Frontend
### SSE Services
- Creates and returns new `EventSource` object pointing to `/sse` on the backend
### App
- Added `sse` and `listening` state
- Added new `useEffect` which:
  - Checks whether `listening` is false and `sse` is `null`
  - If so, creates new `sse` object using the services file
  - Attaches an error listener
  - Attaches an `updatedMonitor` listener:
    - Updates monitor state
    - Updates monitor stored in `runData` if necessary
  - Attaches a `newRun` listener:
    - Adds new run to `runData` if necessary
  - Attaches an `updatedRun` listener:
    - Updates `runData` if necessary
  - Returns a cleanup function which closes the sse connection
# Testing
- Observed monitor switch to failing and runs arrive in real time - both with dual and single ping systems