### PR TITLE
Adding option for email notifications (smtp)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,13 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.5.1",
-        "bree": "^9.1.3",
         "cors": "^2.8.5",
         "cron-parser": "^4.9.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-router": "^0.0.1",
         "nanoid": "^5.0.2",
+        "nodemailer": "^6.9.7",
         "path": "^0.12.7",
         "pg": "^8.11.3",
         "pg-boss": "^9.0.3",
@@ -1675,6 +1675,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
       "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1729,14 +1730,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@breejs/later": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@breejs/later/-/later-4.1.0.tgz",
-      "integrity": "sha512-QgGnZ9b7o4k0Ai1ZbTJWwZpZcFK9d+Gb+DyNt4UT9x6IEIs5HVu0iIlmgzGqN+t9MoJSpSPo9S/Mm51UtHr3JA==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1925,11 +1918,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
@@ -2219,11 +2207,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2244,26 +2227,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bree": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/bree/-/bree-9.1.3.tgz",
-      "integrity": "sha512-oqto4iG7MG2xdRKU0MhFNPTq7ZSztKvalohO3nyu4EIyy3SKpLDX92LkptcGTl6BE2RpQLrzgBP3HoPtWlWBaA==",
-      "dependencies": {
-        "@breejs/later": "^4.1.0",
-        "boolean": "^3.2.0",
-        "combine-errors": "^3.0.3",
-        "cron-validate": "^1.4.3",
-        "human-interval": "^2.0.1",
-        "is-string-and-not-blank": "^0.0.2",
-        "is-valid-path": "^0.1.1",
-        "ms": "^2.1.3",
-        "p-wait-for": "3",
-        "safe-timers": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=12.17.0 <13.0.0-0||>=13.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -2452,15 +2415,6 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
-    "node_modules/combine-errors": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
-      "integrity": "sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==",
-      "dependencies": {
-        "custom-error-instance": "2.1.1",
-        "lodash.uniqby": "4.5.0"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2578,14 +2532,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/cron-validate": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cron-validate/-/cron-validate-1.4.5.tgz",
-      "integrity": "sha512-nKlOJEnYKudMn/aNyNH8xxWczlfpaazfWV32Pcx/2St51r2bxWbGhZD7uwzMcRhunA/ZNL+Htm/i0792Z59UMQ==",
-      "dependencies": {
-        "yup": "0.32.9"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2599,11 +2545,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/custom-error-instance": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
-      "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3623,14 +3564,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/human-interval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-2.0.1.tgz",
-      "integrity": "sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==",
-      "dependencies": {
-        "numbered": "^1.1.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3841,36 +3774,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-invalid-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
-      "integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
-      "dependencies": {
-        "is-glob": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-invalid-path/node_modules/is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-invalid-path/node_modules/is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-      "dependencies": {
-        "is-extglob": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -3971,22 +3874,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-string-and-not-blank": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/is-string-and-not-blank/-/is-string-and-not-blank-0.0.2.tgz",
-      "integrity": "sha512-FyPGAbNVyZpTeDCTXnzuwbu9/WpNXbCfbHXLpCRpN4GANhS00eEIP5Ef+k5HYSNIzIhdN9zRDoBj6unscECvtQ==",
-      "dependencies": {
-        "is-string-blank": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
-      }
-    },
-    "node_modules/is-string-blank": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
-      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
-    },
     "node_modules/is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -4015,17 +3902,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-valid-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
-      "integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
-      "dependencies": {
-        "is-invalid-path": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-weakref": {
@@ -4167,56 +4043,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
-    "node_modules/lodash._baseiteratee": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
-      "integrity": "sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==",
-      "dependencies": {
-        "lodash._stringtopath": "~4.8.0"
-      }
-    },
-    "node_modules/lodash._basetostring": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
-      "integrity": "sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw=="
-    },
-    "node_modules/lodash._baseuniq": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-      "integrity": "sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==",
-      "dependencies": {
-        "lodash._createset": "~4.0.0",
-        "lodash._root": "~3.0.0"
-      }
-    },
-    "node_modules/lodash._createset": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-      "integrity": "sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA=="
-    },
-    "node_modules/lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ=="
-    },
-    "node_modules/lodash._stringtopath": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
-      "integrity": "sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==",
-      "dependencies": {
-        "lodash._basetostring": "~4.12.0"
-      }
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -4227,15 +4053,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.uniqby": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
-      "integrity": "sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==",
-      "dependencies": {
-        "lodash._baseiteratee": "~4.7.0",
-        "lodash._baseuniq": "~4.6.0"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4344,11 +4161,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/nanoclone": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
-    },
     "node_modules/nanoid": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.2.tgz",
@@ -4404,6 +4216,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.7.tgz",
+      "integrity": "sha512-rUtR77ksqex/eZRLmQ21LKVH5nAAsVicAtAYudK7JgwenEDZ0UIQ1adUGqErz7sMkWYxWTTU1aeP2Jga6WQyJw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.0.1",
@@ -4498,11 +4318,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/numbered": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/numbered/-/numbered-1.1.0.tgz",
-      "integrity": "sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4603,14 +4418,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4655,17 +4462,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -4673,20 +4469,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/p-wait-for": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
-      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
-      "dependencies": {
-        "p-timeout": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/packet-reader": {
@@ -5031,11 +4813,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/property-expr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5157,7 +4934,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -5347,11 +5125,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-timers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-timers/-/safe-timers-1.1.0.tgz",
-      "integrity": "sha512-9aqY+v5eMvmRaluUEtdRThV1EjlSElzO7HuCj0sTW9xvp++8iJ9t/RWGNWV6/WHcUJLHpyT2SNf/apoKTU2EpA=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5717,11 +5490,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/touch": {
       "version": "3.1.0",
@@ -6104,23 +5872,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yup": {
-      "version": "0.32.9",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.9.tgz",
-      "integrity": "sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.5",
-        "@types/lodash": "^4.14.165",
-        "lodash": "^4.17.20",
-        "lodash-es": "^4.17.15",
-        "nanoclone": "^0.2.1",
-        "property-expr": "^2.0.4",
-        "toposort": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     }
   }

--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,7 @@
     "express": "^4.18.2",
     "express-router": "^0.0.1",
     "nanoid": "^5.0.2",
+    "nodemailer": "^6.9.7",
     "path": "^0.12.7",
     "pg": "^8.11.3",
     "pg-boss": "^9.0.3",

--- a/app/src/notifications/handleNotifications.js
+++ b/app/src/notifications/handleNotifications.js
@@ -1,9 +1,17 @@
 import slack from './providers/slack.js';
+import smtp from './providers/smtp.js';
 import formatNotification from './formatNotification.js';
+import 'dotenv/config';
 
 const handleNotifications = (monitor, run) => {
   const data = formatNotification(monitor, run);
-  slack.sendNotification(data);
+  
+  if (process.env.SLACK_WEBHOOK_URL) {
+    slack.sendNotification(data);
+  } else if (process.env.SMTP_HOST) {
+    smtp.sendNotification(data);
+  }
+
 };
 
 export default handleNotifications;

--- a/app/src/notifications/handleNotifications.js
+++ b/app/src/notifications/handleNotifications.js
@@ -8,7 +8,9 @@ const handleNotifications = (monitor, run) => {
   
   if (process.env.SLACK_WEBHOOK_URL) {
     slack.sendNotification(data);
-  } else if (process.env.SMTP_HOST) {
+  } 
+  
+  if (process.env.SMTP_HOST) {
     smtp.sendNotification(data);
   }
 

--- a/app/src/notifications/providers/smtp.js
+++ b/app/src/notifications/providers/smtp.js
@@ -1,0 +1,26 @@
+import 'dotenv/config';
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT, 
+    secure: false,
+    auth: {
+      user: process.env.EMAIL,
+      pass: process.env.EMAIL_PASSWORD,
+    },
+  });
+
+const smtp = {
+    async sendNotification(text) {
+        await transporter.sendMail({
+            from: process.env.SMTP_FROM,
+            to: process.env.SMTP_TO,
+            subject: 'Sundial Alert: Your monitor has failed!',
+            text: text,
+        });
+    }
+};
+
+export default smtp;
+  


### PR DESCRIPTION
The time has finally come for email notifications! A user can enter in the fields: `SMTP_HOST`, `SMTP_PORT`, `EMAIL`, `EMAIL_PASSWORD`, `SMTP_FROM`, `SMTP_TO`, and then notifications will be sent to the email indicated in `SMTP_TO`. This uses the Nodemailer npm package.

I did it such that email notifications will be considered 'on' or 'active' if the user has the variable `SMTP_HOST` in their .env file. If they instead have `SLACK_WEBHOOK_URL` , they will be sent Slack notifications. No notifications will be sent if they don't have either of those environment variables.

### How to Test
I used Forward Email to set this up. It is the outbound SMTP service (but I also used it for email forwarding). The Gmail SMTP service is not available without using OAUTH2, which Nodemailer does not support. Online tutorials will say that you can just create an 'insecure' app, but that's not an available option any more.

1. Set up outbound SMTP service. You can use MailerSend or SendGrid, but be warned that you **cannot** use a gmail address to send outgoing mail. You must use a domain that you own. 
2. Add env variables from values designated in outbound SMTP service.
3. Wait for a job to fail and get an email!

![Screenshot 2023-10-28 at 8 23 07 PM](https://github.com/Sundial-Inc/server/assets/10123446/d153c4a6-0f62-42ca-afda-aeb15c69c4cb)
![Screenshot 2023-10-28 at 8 22 54 PM](https://github.com/Sundial-Inc/server/assets/10123446/2647a712-8f38-4363-9b7a-05117825363b)
![This is just to show that we (thankfully) only send the initial failing email for a continuously failing job](https://github.com/Sundial-Inc/server/assets/10123446/9ee1b91f-203c-45b0-a62d-12d0ec800d18)

### Notes

`SMTP_FROM` **must** be an email address with your domain name (this is not a real email address, btw). If using Forward Email, you can only set this up by paying for a paid plan ($3) because 1) you need a password (only available on paid plan) and 2)the free plan only supports the Gmail SMTP service. Their instructions include making a 'insecure' app to access the Gmail API, which is no longer available. 

If you're using MailerSend, you can set this up for free, but you need to have your account 'approved' in order to send emails to domains *other than your own* (this is the value for `SMTP_TO`). Approval process is filling out a form about your 'business' and they manually approve you. They rejected me because my domain/website did not have content on it (my content is hosted on a subdomain that was not indicated). I do not know if there are other caveats in getting approved.

If you are going to try another outbound SMTP service like SendGrid or SMTP2GO, be warned that you **must** sign up with a 'work' email, i.e. it cannot be from a public domain, like gmail.