### PR TITLE
Pagination

### DIFF
--- a/app/src/controllers/monitor.js
+++ b/app/src/controllers/monitor.js
@@ -41,7 +41,9 @@ const getMonitors = async (req, res, next) => {
 const getMonitorRuns = async (req, res, next) => {
   try {
     const id = req.params.id;
-    const runs = await dbGetRunsByMonitorId(id);
+    const limit = req.query.limit;
+    const offset = req.query.offset;
+    const runs = await dbGetRunsByMonitorId(id, limit, offset);
     res.json(runs);
   } catch (error) {
     next(error);

--- a/app/src/controllers/monitor.js
+++ b/app/src/controllers/monitor.js
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
-import { dbGetAllMonitors, dbGetRunsByMonitorId, dbAddMonitor, dbDeleteMonitor } from '../db/queries.js';
+import { dbGetAllMonitors, dbGetRunsByMonitorId, dbAddMonitor, dbDeleteMonitor, dbGetTotalRunsByMonitorId } from '../db/queries.js';
+import calculateTotalPages from '../utils/calculateTotalPages.js';
 
 const validMonitor = (monitor) => {
   if (typeof monitor !== 'object') {
@@ -43,8 +44,15 @@ const getMonitorRuns = async (req, res, next) => {
     const id = req.params.id;
     const limit = req.query.limit;
     const offset = req.query.offset;
+
     const runs = await dbGetRunsByMonitorId(id, limit, offset);
-    res.json(runs);
+    const totalRuns = await dbGetTotalRunsByMonitorId(id);
+    const totalPages = calculateTotalPages(limit, totalRuns);
+
+    res.json({
+      runs,
+      totalPages,
+    });
   } catch (error) {
     next(error);
   }

--- a/app/src/controllers/sse.js
+++ b/app/src/controllers/sse.js
@@ -17,7 +17,6 @@ const getSse = (request, response) => {
 
   clients.push(newClient);
   console.log(`New sse connection: ${clientId}`);
-  console.log(clients);
 
   request.on('close', () => {
     console.log(`${clientId}: Sse connection closed`);

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -173,15 +173,16 @@ const dbGetRunByRunToken = async (runToken) => {
   return run[0];
 };
 
-const dbGetRunsByMonitorId = async (id) => {
+const dbGetRunsByMonitorId = async (id, limit, offset) => {
   const GET_RUNS = `
     SELECT * FROM run
     WHERE monitor_id = $1
-    ORDER BY time DESC;
+    ORDER BY time DESC
+    LIMIT $2 OFFSET $3
   `;
 
   const errorMessage = 'Unable to fetch runs by monitor id from database.';
-  return await handleDatabaseQuery(GET_RUNS, errorMessage, id);
+  return await handleDatabaseQuery(GET_RUNS, errorMessage, id, limit, offset);
 };
 
 export {

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -169,8 +169,8 @@ const dbGetRunByRunToken = async (runToken) => {
   `;
   const errorMessage = 'Unable to fetch run by run token from database.';
 
-  const run = await handleDatabaseQuery(GET_RUN, errorMessage, runToken);
-  return run[0];
+  const rows = await handleDatabaseQuery(GET_RUN, errorMessage, runToken);
+  return rows[0];
 };
 
 const dbGetRunsByMonitorId = async (id, limit, offset) => {
@@ -180,9 +180,20 @@ const dbGetRunsByMonitorId = async (id, limit, offset) => {
     ORDER BY time DESC
     LIMIT $2 OFFSET $3
   `;
-
   const errorMessage = 'Unable to fetch runs by monitor id from database.';
+
   return await handleDatabaseQuery(GET_RUNS, errorMessage, id, limit, offset);
+};
+
+const dbGetTotalRunsByMonitorId = async (id) => {
+  const GET_TOTAL = `
+    SELECT count(*) FROM run
+    WHERE monitor_id = $1
+  `;
+  const errorMessage = 'Unable to fetch total runs by monitor id from database.';
+
+  const rows = await handleDatabaseQuery(GET_TOTAL, errorMessage, id);
+  return rows[0].count;
 };
 
 export {
@@ -199,4 +210,5 @@ export {
   dbUpdateNoStartRun,
   dbGetRunByRunToken,
   dbGetRunsByMonitorId,
+  dbGetTotalRunsByMonitorId,
 };

--- a/app/src/utils/calculateTotalPages.js
+++ b/app/src/utils/calculateTotalPages.js
@@ -1,0 +1,5 @@
+const calculateTotalPages = (pageSize, totalEntries) => {
+  return Math.ceil(totalEntries / pageSize);
+};
+
+export default calculateTotalPages;

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -39,6 +39,7 @@ const App = () => {
   const [monitors, setMonitors] = useState([]);
   const [currMonitor, setCurrMonitor] = useState(null);
   const [runs, setRuns] = useState([]);
+  const [totalPages, setTotalPages] = useState(0);
   const [page, setPage] = useState(1);
   const [displayAddForm, setDisplayAddForm] = useState(false);
   const [displayWrapper, setDisplayWrapper] = useState(false);
@@ -110,6 +111,8 @@ const App = () => {
       });
   
       newSse.addEventListener('newRun', (event) => {
+        if (page !== 1) return;
+
         const newRun = JSON.parse(event.data);
         console.log('New run:', newRun);
 
@@ -149,19 +152,19 @@ const App = () => {
 
     return () => {
       if (sse) {
-        console.log('Closing sse connection.');
         sse.close();
         setSse(null);
         setListening(false);
       }
     }
-  }, [sse, listening, currMonitor]);
+  }, [sse, listening, currMonitor, page]);
 
   useEffect(() => {
     const fetchRuns = async () => {
       try { 
         const data = await getRuns(currMonitor.id, PAGE_LIMIT, calculateOffset(page, PAGE_LIMIT));
-        setRuns(data);
+        setRuns(data.runs);
+        setTotalPages(data.totalPages);
       } catch (error) {
         handleAxiosError(error);
       }
@@ -214,13 +217,9 @@ const App = () => {
   }
 
   const handleDisplayRuns = async (monitorId) => {
-    try {
-      setPage(1);
-      setCurrMonitor(findMonitor(monitorId));
-      setDisplayRunsList(true);
-    } catch (error) {
-      handleAxiosError(error);
-    }
+    setPage(1);
+    setCurrMonitor(findMonitor(monitorId));
+    setDisplayRunsList(true);
   }
 
   const handlePageChange = (event, newPage) => {
@@ -238,7 +237,8 @@ const App = () => {
       onDeleteMonitor={handleClickDeleteMonitor}
       closeRuns={() => setDisplayRunsList(false)}
       page={page}
-      onPageChange={handlePageChange} />;
+      onPageChange={handlePageChange}
+      totalPages={totalPages} />;
   } else {
     componentToRender = (
       <MonitorsList 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -10,6 +10,8 @@ import PaddedAlert from './components/PaddedAlert';
 import RunsList from './components/RunsList'
 import generateWrapper from './utils/generateWrapper';
 import { getSse } from './services/sse';
+import { PAGE_LIMIT } from './constants/pagination';
+import calculateOffset from './utils/calculateOffset';
 
 const theme = createTheme({
   typography: {
@@ -35,7 +37,9 @@ const theme = createTheme({
 
 const App = () => {
   const [monitors, setMonitors] = useState([]);
-  const [runData, setRunData] = useState({});
+  const [currMonitor, setCurrMonitor] = useState(null);
+  const [runs, setRuns] = useState([]);
+  const [page, setPage] = useState(1);
   const [displayAddForm, setDisplayAddForm] = useState(false);
   const [displayWrapper, setDisplayWrapper] = useState(false);
   const [displayRunsList, setDisplayRunsList] = useState(false);
@@ -44,8 +48,6 @@ const App = () => {
   const [successMessages, addSuccessMessage] = useTemporaryMessages(3000);
   const [sse, setSse] = useState(null);
   const [listening, setListening] = useState(false);
-
-  console.log(runData);
 
   const handleAxiosError = (error) => {
     console.log(error);
@@ -98,30 +100,26 @@ const App = () => {
           }
         }));
         
-        setRunData(runData => {
-          if (runData.monitor && runData.monitor.id === updatedMonitor.id) {
-            return {
-              monitor: updatedMonitor,
-              runs: runData.runs,
-            };
+        setCurrMonitor(currMonitor => {
+          if (currMonitor && currMonitor.id === updatedMonitor.id) {
+            return updatedMonitor;
           } else {
-            return runData;
+            return currMonitor;
           }
-        });
+        })
       });
   
       newSse.addEventListener('newRun', (event) => {
         const newRun = JSON.parse(event.data);
         console.log('New run:', newRun);
 
-        setRunData(runData => {
-          if (runData.monitor && runData.monitor.id === newRun.monitor_id && !runData.runs.find(run => run.id === newRun.id)) {
-            return {
-              monitor: runData.monitor,
-              runs: [newRun].concat(runData.runs),
-            };
+        setRuns(runs => {
+          if (currMonitor && currMonitor.id === newRun.monitor_id && !runs.find(run => run.id === newRun.id)) {
+            const newRunData = [newRun].concat(runs);
+            newRunData.length = PAGE_LIMIT;
+            return newRunData;
           } else {
-            return runData;
+            return runs;
           }
         });
       });
@@ -130,20 +128,17 @@ const App = () => {
         const updatedRun = JSON.parse(event.data);
         console.log('Updated run:', updatedRun);
   
-        setRunData(runData => {
-          if (runData.monitor && runData.monitor.id === updatedRun.monitor_id) {
-            return {
-              monitor: runData.monitor,
-              runs: runData.runs.map(run => {
+        setRuns(runs => {
+          if (currMonitor && currMonitor.id === updatedRun.monitor_id) {
+            return runs.map(run => {
                 if (run.id === updatedRun.id) {
                   return updatedRun;
                 } else {
                   return run;
                 }
-              }),
-            };
+              });
           } else {
-            return runData;
+            return runs;
           }
         });
       });
@@ -157,9 +152,25 @@ const App = () => {
         console.log('Closing sse connection.');
         sse.close();
         setSse(null);
+        setListening(false);
       }
     }
-  }, [sse, listening]);
+  }, [sse, listening, currMonitor]);
+
+  useEffect(() => {
+    const fetchRuns = async () => {
+      try { 
+        const data = await getRuns(currMonitor.id, PAGE_LIMIT, calculateOffset(page, PAGE_LIMIT));
+        setRuns(data);
+      } catch (error) {
+        handleAxiosError(error);
+      }
+    }
+
+    if (currMonitor) {
+      fetchRuns();
+    }
+  }, [currMonitor, page]);
 
   const handleClickNewMonitorButton = (e) => {
     setDisplayAddForm(true);
@@ -203,13 +214,17 @@ const App = () => {
   }
 
   const handleDisplayRuns = async (monitorId) => {
-    try { 
-      const runs = await getRuns(monitorId);
-      setRunData({ monitor: findMonitor(monitorId), runs: runs });
+    try {
+      setPage(1);
+      setCurrMonitor(findMonitor(monitorId));
       setDisplayRunsList(true);
     } catch (error) {
       handleAxiosError(error);
     }
+  }
+
+  const handlePageChange = (event, newPage) => {
+    setPage(newPage);
   }
 
   let componentToRender;
@@ -217,7 +232,13 @@ const App = () => {
   if (displayAddForm) {
     componentToRender = <AddMonitorForm onSubmitForm={handleClickSubmitNewMonitor} onBack={handleClickBackButton} addErrorMessage={addErrorMessage} />;
   } else if (displayRunsList) {
-    componentToRender = <RunsList runData={runData} onDeleteMonitor={handleClickDeleteMonitor} closeRuns={() => setDisplayRunsList(false)}/>;
+    componentToRender = <RunsList
+      monitor={currMonitor}
+      runs={runs}
+      onDeleteMonitor={handleClickDeleteMonitor}
+      closeRuns={() => setDisplayRunsList(false)}
+      page={page}
+      onPageChange={handlePageChange} />;
   } else {
     componentToRender = (
       <MonitorsList 

--- a/ui/src/components/RunsList.jsx
+++ b/ui/src/components/RunsList.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { List, Box, Typography, Button, Divider, Grid } from '@mui/material';
+import { List, Box, Typography, Button, Divider, Grid, Pagination } from '@mui/material';
 import Run from './Run'
 import DeleteButton from './DeleteButton';
 
-const RunsList = ({ runData, onDeleteMonitor, closeRuns }) => {
-  const { monitor, runs } = runData;
-
+const RunsList = ({ monitor, runs, onDeleteMonitor, closeRuns, page, onPageChange }) => {
   const handleDeleteMonitor = () => {
     onDeleteMonitor(monitor.id);
     closeRuns();
@@ -66,11 +64,12 @@ const RunsList = ({ runData, onDeleteMonitor, closeRuns }) => {
             </Grid>
           </Grid>
           <Divider />
-            <List>
-              {runs.map((run) => (
-              <Run run={run} key={run.id}/>
-              ))}
-            </List>
+          <List>
+            {runs.map((run) => (
+            <Run run={run} key={run.id}/>
+            ))}
+          </List>
+          <Pagination count={5} size="large" page={page} onChange={onPageChange} />
         </Box>
       </div>
     </div>

--- a/ui/src/components/RunsList.jsx
+++ b/ui/src/components/RunsList.jsx
@@ -3,7 +3,7 @@ import { List, Box, Typography, Button, Divider, Grid, Pagination } from '@mui/m
 import Run from './Run'
 import DeleteButton from './DeleteButton';
 
-const RunsList = ({ monitor, runs, onDeleteMonitor, closeRuns, page, onPageChange }) => {
+const RunsList = ({ monitor, runs, onDeleteMonitor, closeRuns, page, onPageChange, totalPages }) => {
   const handleDeleteMonitor = () => {
     onDeleteMonitor(monitor.id);
     closeRuns();
@@ -69,7 +69,9 @@ const RunsList = ({ monitor, runs, onDeleteMonitor, closeRuns, page, onPageChang
             <Run run={run} key={run.id}/>
             ))}
           </List>
-          <Pagination count={5} size="large" page={page} onChange={onPageChange} />
+          <Box display="flex" alignItems="center" justifyContent="center">
+            <Pagination count={totalPages} size="large" page={page} onChange={onPageChange} />
+          </Box>
         </Box>
       </div>
     </div>

--- a/ui/src/constants/pagination.js
+++ b/ui/src/constants/pagination.js
@@ -1,0 +1,1 @@
+export const PAGE_LIMIT = 10;

--- a/ui/src/services/monitors.js
+++ b/ui/src/services/monitors.js
@@ -12,8 +12,8 @@ export const getMonitors = async () => {
   return data;
 };
 
-export const getRuns = async (id) => {
-  const { data } = await axios.get(BASE_URL + GET_RUNS + String(id));
+export const getRuns = async (id, limit, offset) => {
+  const { data } = await axios.get(BASE_URL + GET_RUNS + String(id) + `?limit=${limit}&offset=${offset}`);
   return data;
 };
 

--- a/ui/src/utils/calculateOffset.js
+++ b/ui/src/utils/calculateOffset.js
@@ -1,0 +1,5 @@
+const calculateOffset = (page, pageLimit) => {
+  return (page - 1) * pageLimit;
+};
+
+export default calculateOffset;


### PR DESCRIPTION
# Changes
## Backend
- `getMonitorRuns` in `monitor` controller now expects `limit` and `offset` as query parameters.
- `limit` and `offset` are passed to modified `dbGetRunsByMonitorId` which uses them in its database query to return only a subset of results
- new database method `dbGetTotalRunsByMonitorId`
- `calcualteTotalPages` uses the `totalRuns` and `limit`
- `getMonitorRuns` send the subset of `runs` and `totalPages` to the user
## Frontend
- Added new state: `currMonitor`, `page`, `totalPages`
- `runData` state has been modified to only include the `runs` - no longer contains information about the currently displayed monitor. Renamed to `runs`. Many lines needed adjusting to accommodate this change - for instance, in setting up the `sse` listeners
- Logic for fetching runs has been moved to a `useEffect` which triggers when `currMonitor` or `page` state changes
- `Pagination` material UI element is used in `runsList`