### PR TITLE
added monitors appear in real time - nice for demo

### DIFF
--- a/app/src/controllers/monitor.js
+++ b/app/src/controllers/monitor.js
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 import { dbGetAllMonitors, dbGetRunsByMonitorId, dbAddMonitor, dbDeleteMonitor, dbGetTotalRunsByMonitorId } from '../db/queries.js';
 import calculateTotalPages from '../utils/calculateTotalPages.js';
+import { sendNewMonitor } from './sse.js';
 
 const validMonitor = (monitor) => {
   if (typeof monitor !== 'object') {
@@ -76,6 +77,7 @@ const addMonitor = async (req, res, next) => {
 
   try {
     const monitor = await dbAddMonitor(newMonitorData);
+    sendNewMonitor(monitor);
     res.json(monitor);
   } catch (error) {
     next(error);

--- a/app/src/controllers/sse.js
+++ b/app/src/controllers/sse.js
@@ -28,6 +28,15 @@ const sendMessage = (message) => {
   clients.forEach(client => client.response.write(message));
 };
 
+const sendNewMonitor = (monitor) => {
+  const message =
+    'event: newMonitor\n' +
+    `data: ${JSON.stringify(monitor)}` +
+    '\n\n';
+
+  sendMessage(message);
+};
+
 const sendUpdatedMonitor = (monitor) => {
   const message =
     'event: updatedMonitor\n' +
@@ -57,6 +66,7 @@ const sendUpdatedRun = (run) => {
 
 export {
   getSse,
+  sendNewMonitor,
   sendUpdatedMonitor,
   sendNewRun,
   sendUpdatedRun,

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -93,7 +93,13 @@ const App = () => {
         const newMonitor = JSON.parse(event.data);
         console.log('New Monitor:', newMonitor);
 
-        setMonitors(monitors => monitors.concat(newMonitor));
+        setMonitors(monitors => {
+          if (!monitors.find(monitor => monitor.id === newMonitor.id)) {
+            return monitors.concat(newMonitor)
+          } else {
+            return monitors;
+          }
+        });
       });
 
       newSse.addEventListener('updatedMonitor', (event) => {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -89,6 +89,13 @@ const App = () => {
         }, 5000);
       };
 
+      newSse.addEventListener('newMonitor', (event) => {
+        const newMonitor = JSON.parse(event.data);
+        console.log('New Monitor:', newMonitor);
+
+        setMonitors(monitors => monitors.concat(newMonitor));
+      });
+
       newSse.addEventListener('updatedMonitor', (event) => {
         const updatedMonitor = JSON.parse(event.data);
         console.log('Updated monitor:', updatedMonitor);


### PR DESCRIPTION
- added functionality for new monitors to appear in real time - mostly done for demo purposes
- method `sendNewMonitor` is used in only one place - the `addMonitor` route in the monitor controller