### PR TITLE
added concurrent workers to solo, start and end queues

### DIFF
--- a/app/src/db/MissedPingsMq.js
+++ b/app/src/db/MissedPingsMq.js
@@ -28,9 +28,16 @@ const MissedPingsMq = {
 
     await this.boss.start();
     await this.boss.deleteAllQueues();
-    await this.boss.work('start', startWorker);
-    await this.boss.work('end', endWorker);
-    await this.boss.work('solo', soloWorker);
+    
+    const options = {
+      teamSize: 100,
+      teamConcurrency: 100,
+    }
+
+    await this.boss.work('start', options, startWorker);
+    await this.boss.work('end', options, endWorker);
+    await this.boss.work('solo', options, soloWorker);
+    
     await this.boss.work('maintenance', maintenanceWorker);
 
     console.log('PgBoss initialized and ready for use.');

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -2,7 +2,7 @@ import express from 'express';
 const router = express.Router();
 import { getMonitors, getMonitorRuns, addMonitor, deleteMonitor } from '../controllers/monitor.js';
 import { addPing } from '../controllers/ping.js';
-import { getUpdates, addJob, syncUpdates } from '../controllers/scheduler.js';
+import { getUpdates, addJob } from '../controllers/scheduler.js';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitorRuns);


### PR DESCRIPTION
- Changed `pg-boss` configuration options for solo, start and end queues
- Each polling interval (every two seconds) up to 100 jobs can be pulled off and 100 concurrent workers can be spun up to handle them