### PR TITLE
Send jwt frontend

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -13,7 +13,6 @@ app.use(cors());
 app.use(express.json());
 app.use('/api/monitors', authenticator);
 app.use('/api/pings', authenticator);
-app.use('/sse', authenticator);
 
 app.use('/', home);
 app.use('/api', api);

--- a/app/src/controllers/user.js
+++ b/app/src/controllers/user.js
@@ -45,6 +45,18 @@ const addUser = async (request, response, next) => {
   }
 };
 
+const userCount = async (request, response, next) => {
+  try {
+    const usernames = await dbGetAllUsernames();
+    response.status(200).send({
+      count: usernames.length,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export {
   addUser,
+  userCount
 };

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -2,7 +2,7 @@ import express from 'express';
 const router = express.Router();
 import { getMonitors, getMonitor, getMonitorRuns, addMonitor, deleteMonitor, updateMonitor } from '../controllers/monitor.js';
 import { addPing } from '../controllers/ping.js';
-import { addUser } from '../controllers/user.js';
+import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
 
 router.get('/monitors', getMonitors);
@@ -15,6 +15,7 @@ router.delete('/monitors/:id', deleteMonitor);
 router.post('/pings/:endpoint_key', addPing);
 
 router.post('/users', addUser);
+router.get('/users/count', userCount);
 
 router.post('/login', login);
 

--- a/ui/src/components/AddJobForm.jsx
+++ b/ui/src/components/AddJobForm.jsx
@@ -118,7 +118,7 @@ const AddJobForm = ({ onSubmitAddForm, addErrorMessage }) => {
               padding: '5px',
             }}
             >
-            <PopoverButton variant='contained' onValidate={handleValidateForm} onAction={handleSubmitForm} buttonName={'Submit'}heading={"Are you sure of the changes you've made?"}></PopoverButton>
+            <PopoverButton variant='contained' onValidate={handleValidateForm} onAction={handleSubmitForm} buttonName={'Submit'} heading={"Are you sure of the changes you've made?"}></PopoverButton>
           </Box>
         </Box>
       </FormControl>

--- a/ui/src/components/CreateUserForm.jsx
+++ b/ui/src/components/CreateUserForm.jsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import UserForm from './UserForm';
 
 const CreateUserForm = ({onSubmitCreateUserForm, addErrorMessage}) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const navigate = useNavigate();
 
   const validateForm = () => {
     if (username.length < 2) {
@@ -19,7 +17,7 @@ const CreateUserForm = ({onSubmitCreateUserForm, addErrorMessage}) => {
   }
     return true;
   }
-    
+
   const handleSubmitForm = (event) => {
     event.preventDefault()
     
@@ -29,8 +27,7 @@ const CreateUserForm = ({onSubmitCreateUserForm, addErrorMessage}) => {
           password: password
       };
   
-      navigate('/');
-      return onSubmitCreateUserForm(userData);
+      onSubmitCreateUserForm(userData);
     }
   }
 

--- a/ui/src/components/CreateUserForm.jsx
+++ b/ui/src/components/CreateUserForm.jsx
@@ -3,49 +3,49 @@ import { useNavigate } from 'react-router-dom';
 import UserForm from './UserForm';
 
 const CreateUserForm = ({onSubmitCreateUserForm, addErrorMessage}) => {
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
 
-    const validateForm = () => {
-        if (username.length < 2) {
-            addErrorMessage("Must have a username longer than 1 character.");
-            return false;
-        }
-    
-        if (password.length < 8) {
-            addErrorMessage("Must have a password longer than 8 characters");
-            return false;
-        }
-        return true;
-    }
-    
-    const handleSubmitForm = (event) => {
-        event.preventDefault()
-        
-        if(validateForm()) {
-            const userData = {
-                username: username,
-                password: password
-            };
-        
-            navigate('/');
-            return onSubmitCreateUserForm(userData);
-        }
+  const validateForm = () => {
+    if (username.length < 2) {
+      addErrorMessage("Must have a username longer than 1 character.");
+      return false;
     }
 
+    if (password.length < 8) {
+      addErrorMessage("Must have a password longer than 8 characters");
+      return false;
+  }
+    return true;
+  }
+    
+  const handleSubmitForm = (event) => {
+    event.preventDefault()
+    
+    if(validateForm()) {
+      const userData = {
+          username: username,
+          password: password
+      };
+  
+      navigate('/');
+      return onSubmitCreateUserForm(userData);
+    }
+  }
 
-    return (
-        <>
-            <UserForm 
-                username={username}
-                setUsername={setUsername}
-                password={password}
-                setPassword={setPassword}
-                onSubmit={handleSubmitForm}
-                formName={'Create User'}/>
-        </>
-    )
+
+  return (
+    <>
+      <UserForm 
+          username={username}
+          setUsername={setUsername}
+          password={password}
+          setPassword={setPassword}
+          onSubmit={handleSubmitForm}
+          formName={'Create User'}/>
+    </>
+  )
 };
 
 export default CreateUserForm;

--- a/ui/src/components/EditForm.jsx
+++ b/ui/src/components/EditForm.jsx
@@ -138,7 +138,7 @@ const EditForm = ({ onSubmitEditForm, addErrorMessage }) => {
                 padding: '5px',
               }}
               >
-              <PopoverButton variant='contained' onValidate={handleValidateForm} onAction={handleSubmitForm} buttonName={'Submit'}heading={"Are you sure of the changes you've made?"}></PopoverButton>
+              <PopoverButton variant='contained' onValidate={handleValidateForm} onAction={handleSubmitForm} buttonName={'Submit'} heading={"Are you sure of the changes you've made?"}></PopoverButton>
             </Box>
           </Box>
         </FormControl>

--- a/ui/src/components/JobsList.jsx
+++ b/ui/src/components/JobsList.jsx
@@ -3,7 +3,7 @@ import { Job } from './Job';
 import { Link } from 'react-router-dom';
 import { CONTAINER_COLOR } from '../constants/colors';
 
-const JobsList = ({ jobs, onDelete, onAddNewJob }) => {
+const JobsList = ({ jobs, onAddNewJob, onDelete }) => {
   const boxStyle = {
     width: '100%',
     padding: '20px',

--- a/ui/src/components/LoginForm.jsx
+++ b/ui/src/components/LoginForm.jsx
@@ -1,36 +1,32 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import UserForm from './UserForm';
 
-
-const LoginForm = ({onSubmitLoginForm}) => {
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const navigate = useNavigate();
+const LoginForm = ({ onSubmitLoginForm }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  
+  const handleSubmitForm = (event) => {
+    event.preventDefault();
+    const credentials = {
+      username: username,
+      password: password
+    };
     
-    const handleSubmitForm = (event) => {
-        event.preventDefault()
-        const credentials = {
-            username: username,
-            password: password
-        };
-        
-        navigate('/');
-        return onSubmitLoginForm(credentials);
-    }
+    onSubmitLoginForm(credentials);
+  };
 
-    return (
-        <div className='login-wrapper'>
-            <UserForm 
-                username={username}
-                setUsername={setUsername}
-                password={password}
-                setPassword={setPassword}
-                onSubmit={handleSubmitForm}
-                formName={'Please Log In'}
-            />
-        </div>
-    )
+  return (
+    <div className='login-wrapper'>
+      <UserForm 
+        username={username}
+        setUsername={setUsername}
+        password={password}
+        setPassword={setPassword}
+        onSubmit={handleSubmitForm}
+        formName={'Please Log In'}
+      />
+    </div>
+  )
 };
 
 export default LoginForm;

--- a/ui/src/components/UserForm.jsx
+++ b/ui/src/components/UserForm.jsx
@@ -14,17 +14,17 @@ const divStyle = {
   maxWidth: '90%', 
 }
 
-const UserForm = ({ username, setUsername, password, setPassword, handleSubmitForm, formName }) => {
+const UserForm = ({ username, setUsername, password, setPassword, onSubmit, formName }) => {
     return (
         <div style={{marginTop: '20px', marginLeft: '5%'}}>
             <div style={divStyle}>
-                <FormControl margin="normal" variant="outlined" sx={{margin: '20px' }}>
+                <FormControl margin="normal" variant="outlined" sx={{margin: '20px' }} >
                         <FormLabel sx={{fontSize:'20px'}}>{formName}</FormLabel>
                         <Box
                             component="form"
                             sx={boxStyle}
-                            onSubmit={handleSubmitForm}
                             autoComplete="off"
+                            onSubmit={onSubmit}
                         >
                         <TextField 
                             required

--- a/ui/src/constants/routes.js
+++ b/ui/src/constants/routes.js
@@ -9,5 +9,5 @@ export const GET_JOB= '/api/monitors/';
 export const CREATE_PING = '/api/pings';
 export const GET_SSE = '/sse';
 export const CREATE_USER = '/api/users';
-export const LOGIN_USER = '/api/login'; //check with backend
-export const CHECK_DB_ADMIN = '/api/verify-created'; //check with backend
+export const LOGIN_USER = '/api/login';
+export const USER_COUNT = '/api/users/count';

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 import '@fontsource/roboto/500.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>
 );

--- a/ui/src/services/config.js
+++ b/ui/src/services/config.js
@@ -1,0 +1,18 @@
+let token;
+
+const setToken = (newToken) => {
+  token = `Bearer ${token}`;
+};
+
+const getConfig = () => {
+  return {
+    headers: {
+      Authorization: token,
+    }
+  };
+};
+
+export {
+  setToken,
+  getConfig,
+};

--- a/ui/src/services/jobs.js
+++ b/ui/src/services/jobs.js
@@ -8,33 +8,40 @@ import {
   DELETE_JOB,
   GET_RUNS,
 } from "../constants/routes";
+import { getConfig } from './config';
 
 export const createJob = async (newJob) => {
-  const { data } = await axios.post(BASE_URL + CREATE_JOB, newJob);
+  const config = getConfig();
+  const { data } = await axios.post(BASE_URL + CREATE_JOB, newJob, config);
   return data;
 };
 
 export const getJobs = async () => {
-  const { data } = await axios.get(BASE_URL + GET_JOBS);
+  const config = getConfig();
+  const { data } = await axios.get(BASE_URL + GET_JOBS, config);
   return data;
 };
 
 export const getJob = async (id) => {
-  const { data } = await axios.get(BASE_URL + GET_JOB + id);
+  const config = getConfig();
+  const { data } = await axios.get(BASE_URL + GET_JOB + id, config);
   return data;
 };
 
 export const updateJob = async (id, newJob) => {
-  const { data } = await axios.put(BASE_URL + UPDATE_JOB + id, newJob);
+  const config = getConfig();
+  const { data } = await axios.put(BASE_URL + UPDATE_JOB + id, newJob, config);
   return data;
 };
 
 export const deleteJob = async (id) => {
-  await axios.delete(BASE_URL + DELETE_JOB + String(id));
+  const config = getConfig();
+  await axios.delete(BASE_URL + DELETE_JOB + String(id), config);
 };
 
 export const getRuns = async (id, limit, offset) => {
-  const { data } = await axios.get(BASE_URL + GET_RUNS + String(id) + `?limit=${limit}&offset=${offset}`);
+  const config = getConfig();
+  const { data } = await axios.get(BASE_URL + GET_RUNS + String(id) + `?limit=${limit}&offset=${offset}`, config);
   return data;
 };
 

--- a/ui/src/services/users.js
+++ b/ui/src/services/users.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { BASE_URL, CREATE_USER, LOGIN_USER, CHECK_DB_ADMIN } from '../constants/routes';
+import { BASE_URL, CREATE_USER, LOGIN_USER, USER_COUNT } from '../constants/routes';
 
 export const createUser = async(userData) => {
     const { data } = await axios.post(BASE_URL + CREATE_USER, userData);
@@ -7,11 +7,12 @@ export const createUser = async(userData) => {
 }
 
 export const logInUser = async(userData) => {
+    console.log(`Request made to ${BASE_URL + LOGIN_USER}`);
     const { data } = await axios.post(BASE_URL + LOGIN_USER, userData);
     return data;
 }
 
 export const checkDBAdmin = async() => {
-    const { data } = await axios.get(BASE_URL + CHECK_DB_ADMIN);
-    return data;
+    const { data } = await axios.get(BASE_URL + USER_COUNT);
+    return data.count > 0;
 }


### PR DESCRIPTION
- On mount: check if database user exists - if not redirect to `/create-user`; check if `window.localStorage` contains web token - if not, redirect to `/login`; otherwise, use `setToken` to configure future API calls to use the token and redirect to `/`
- On successful login store jwt to `window.localStorage`
- API calls now use `getConfig` to set Authorization headers

Note: There are a lot of changes that appear in this pull which are not actual changes - just things moving around. The reason for this is that I intended to move all the monitor logic away from the `App` component into some sort of `MainPage` component. This was to prevent the first error discussed below. However, I quickly realised that was not anywhere near as easy as I had originally thought and so abandoned my quest. Maybe a future change - definitely worthy of its own PR.
## Further thoughts
- When being shown the login page the app still attempts to make a request to `/api/monitors` - this results in an error message being displayed about the lack of webtoken. Would be better if that didn't happen
- Need to handle the case of jwts becoming invalid - should delete from local storage and redirect to `/login`

Despite these error it may be best to merge immediately - as the current version of main does not work at all for communication between front and back end