### PR TITLE
Api key generation

### DIFF
--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -1,5 +1,5 @@
 import { generateHash, compareWithHash } from '../utils/bcrypt.js';
-import { dbAddAPIKey, dbGetAPIKeyList } from '../db/queries.js';
+import { dbAddAPIKey, dbGetAPIKeyList, dbChangeAPIKeyName } from '../db/queries.js';
 import generateAPIKey from '../utils/generateAPIKey.js';
 
 const addAPIKey = async (req, res, next) => {
@@ -8,18 +8,22 @@ const addAPIKey = async (req, res, next) => {
         const hash = await generateHash(apiKey);
         const apiKeyData = {hash};
 
-        // if (name) {
-        //     apiKeyData.name = name;
-        // }
-
-        await dbAddAPIKey(apiKeyData);
-        res.status(201).send(apiKey);
+        let data = await dbAddAPIKey(apiKeyData);
+        res.status(201).send({apiKey: apiKey, id: data.id});
     } catch(error) {
         next(error);
     }
 };
 
-
+const addName = async (req, res, next) => {
+    try {
+        const {name, id} = req.body;
+        await dbChangeAPIKeyName(name, id);
+        res.status(200).send();
+    } catch(error) {
+        next(error);
+    }
+}
 
 const verifyAPIKey = async (req, res, next) => {
     try {
@@ -34,4 +38,4 @@ const verifyAPIKey = async (req, res, next) => {
 
 };
 
-export { addAPIKey, verifyAPIKey };
+export { addAPIKey, verifyAPIKey, addName };

--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -28,7 +28,7 @@ const verifyAPIKey = async (req, res, next) => {
             res.status(200).send();
         }
 
-        res.status(403).send();
+        res.status(401).send();
     } catch(error) {
         next(error);
     }

--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -1,0 +1,37 @@
+import { generateHash } from '../utils/bcrypt.js';
+import { dbAddAPIKey, dbGetAPIKey } from '../db/queries.js';
+
+const addAPIKey = async (req, res, next) => {
+    try {
+        const { apiKey, name } = req.body;
+        const hash = await generateHash(apiKey);
+        const apiKeyData = {hash};
+
+        if (name) {
+            apiKeyData.name = name;
+        }
+
+        await dbAddAPIKey(apiKeyData);
+        res.status(201).send();
+    } catch(error) {
+        next(error);
+    }
+};
+
+const verifyAPIKey = async (req, res, next) => {
+    try {
+        const apiKey = req.body;
+        const hash = await generateHash(apiKey);
+        const apiKeyCheck = await dbGetAPIKey(hash);
+
+        if (apiKeyCheck) {
+            res.status(200).send();
+        }
+
+        res.status(403).send();
+    } catch(error) {
+        next(error);
+    }
+};
+
+export { addAPIKey, verifyAPIKey };

--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -1,22 +1,25 @@
 import { generateHash, compareWithHash } from '../utils/bcrypt.js';
 import { dbAddAPIKey, dbGetAPIKeyList } from '../db/queries.js';
+import generateAPIKey from '../utils/generateAPIKey.js';
 
 const addAPIKey = async (req, res, next) => {
     try {
-        const { apiKey, name } = req.body;
+        const apiKey = generateAPIKey();
         const hash = await generateHash(apiKey);
         const apiKeyData = {hash};
 
-        if (name) {
-            apiKeyData.name = name;
-        }
+        // if (name) {
+        //     apiKeyData.name = name;
+        // }
 
         await dbAddAPIKey(apiKeyData);
-        res.status(201).send();
+        res.status(201).send(apiKey);
     } catch(error) {
         next(error);
     }
 };
+
+
 
 const verifyAPIKey = async (req, res, next) => {
     try {

--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -1,5 +1,5 @@
-import { generateHash } from '../utils/bcrypt.js';
-import { dbAddAPIKey, dbGetAPIKey } from '../db/queries.js';
+import { generateHash, compareWithHash } from '../utils/bcrypt.js';
+import { dbAddAPIKey, dbGetAPIKeyList } from '../db/queries.js';
 
 const addAPIKey = async (req, res, next) => {
     try {
@@ -20,18 +20,15 @@ const addAPIKey = async (req, res, next) => {
 
 const verifyAPIKey = async (req, res, next) => {
     try {
-        const apiKey = req.body;
-        const hash = await generateHash(apiKey);
-        const apiKeyCheck = await dbGetAPIKey(hash);
+        const apiKey = req;
+        const apiKeyList = await dbGetAPIKeyList();
 
-        if (apiKeyCheck) {
-            res.status(200).send();
-        }
-
-        res.status(401).send();
+        const apiKeyCheck = apiKeyList.some(key => compareWithHash(apiKey, key.api_key_hash));
+        return apiKeyCheck;
     } catch(error) {
         next(error);
     }
+
 };
 
 export { addAPIKey, verifyAPIKey };

--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -6,10 +6,11 @@ const addAPIKey = async (req, res, next) => {
     try {
         const apiKey = generateAPIKey();
         const hash = await generateHash(apiKey);
-        const apiKeyData = {hash};
 
-        let data = await dbAddAPIKey(apiKeyData);
-        res.status(201).send({apiKey: apiKey, id: data.id});
+        const prefix = apiKey.slice(0, 8);
+
+        let data = await dbAddAPIKey(hash, prefix);
+        res.status(201).send({apiKey: apiKey, id: data.id, prefix: prefix});
     } catch(error) {
         next(error);
     }
@@ -17,7 +18,9 @@ const addAPIKey = async (req, res, next) => {
 
 const addName = async (req, res, next) => {
     try {
-        const {name, id} = req.body;
+        const id = req.params.id;
+        console.log(id);
+        const {name} = req.body;
         await dbChangeAPIKeyName(name, id);
         res.status(200).send();
     } catch(error) {

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -252,14 +252,9 @@ const dbCallMaintenanceProcedure = async () => {
   return await handleDatabaseQuery(CALL_PROC, errorMessage);
 };
 
-const dbAddAPIKey = async (apiKeyData) => {
-  const columns = ['api_key_hash'];
-  const values = [apiKeyData.hash];
-
-  if (apiKeyData.name) {
-    columns.push('name');
-    values.push(apiKeyData.name);
-  }
+const dbAddAPIKey = async (hash, prefix) => {
+  const columns = ['api_key_hash', 'prefix'];
+  const values = [hash, prefix];
 
   const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');
 

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -281,7 +281,7 @@ const dbGetAPIKey = async (apiKeyHash) => {
   const errorMessage = 'Unable to fetch api key from database.';
 
   const rows = await handleDatabaseQuery(GET_API_KEY, errorMessage, apiKeyHash);
-  return rows[0];
+  return rows[0] > 0;
 }
 
 export {
@@ -304,4 +304,6 @@ export {
   dbGetUserByUsername,
   dbAddUser,
   dbCallMaintenanceProcedure,
+  dbAddAPIKey,
+  dbGetAPIKey
 };

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -251,6 +251,39 @@ const dbCallMaintenanceProcedure = async () => {
   return await handleDatabaseQuery(CALL_PROC, errorMessage);
 };
 
+const dbAddAPIKey = async (apiKeyData) => {
+  const columns = ['api_key_hash'];
+  const values = [apiKeyData.hash];
+
+  if (apiKeyData.name) {
+    columns.push('name');
+    values.push(apiKeyData.name);
+  }
+
+  const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');
+
+  const ADD_API_KEY = `
+    INSERT INTO api_key (${columns})
+    VALUES (${placeholders})
+    RETURNING *;`;
+    const errorMessage = 'Unable to add a api key to database.';
+  
+    const rows = await handleDatabaseQuery(ADD_API_KEY, errorMessage, ...values);
+    return rows[0];
+}
+
+const dbGetAPIKey = async (apiKeyHash) => {
+  const GET_API_KEY = `
+    SELECT api_key_hash 
+    FROM api_key
+    WHERE api_key_hash = $1;`;
+
+  const errorMessage = 'Unable to fetch api key from database.';
+
+  const rows = await handleDatabaseQuery(GET_API_KEY, errorMessage, apiKeyHash);
+  return rows[0];
+}
+
 export {
   dbUpdateMonitorFailing,
   dbUpdateMonitorRecovered,

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -272,16 +272,15 @@ const dbAddAPIKey = async (apiKeyData) => {
     return rows[0];
 }
 
-const dbGetAPIKey = async (apiKeyHash) => {
+const dbGetAPIKeyList = async () => {
   const GET_API_KEY = `
-    SELECT api_key_hash 
-    FROM api_key
-    WHERE api_key_hash = $1;`;
+    SELECT * 
+    FROM api_key`;
 
-  const errorMessage = 'Unable to fetch api key from database.';
+  const errorMessage = 'Unable to fetch api keys from database.';
 
-  const rows = await handleDatabaseQuery(GET_API_KEY, errorMessage, apiKeyHash);
-  return rows[0] > 0;
+  const rows = await handleDatabaseQuery(GET_API_KEY, errorMessage);
+  return rows;
 }
 
 export {
@@ -305,5 +304,5 @@ export {
   dbAddUser,
   dbCallMaintenanceProcedure,
   dbAddAPIKey,
-  dbGetAPIKey
+  dbGetAPIKeyList
 };

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -1,3 +1,4 @@
+import error from '../routes/error.js';
 import dbQuery from './config.js';
 
 const handleDatabaseQuery = async (query, errorMessage, ...params) => {
@@ -265,7 +266,7 @@ const dbAddAPIKey = async (apiKeyData) => {
   const ADD_API_KEY = `
     INSERT INTO api_key (${columns})
     VALUES (${placeholders})
-    RETURNING *;`;
+    RETURNING *`;
     const errorMessage = 'Unable to add a api key to database.';
   
     const rows = await handleDatabaseQuery(ADD_API_KEY, errorMessage, ...values);
@@ -282,6 +283,20 @@ const dbGetAPIKeyList = async () => {
   const rows = await handleDatabaseQuery(GET_API_KEY, errorMessage);
   return rows;
 }
+
+const dbChangeAPIKeyName = async(name, id) => {
+  const CHANGE_NAME = `
+    UPDATE api_key
+    SET name=$1
+    WHERE id=$2
+    RETURNING *
+  `
+
+  const errorMessage = 'Unable to update api key name in database.';
+
+  const rows = handleDatabaseQuery(CHANGE_NAME, errorMessage, name, id);
+  return rows[0];
+};
 
 export {
   dbUpdateMonitorFailing,
@@ -304,5 +319,6 @@ export {
   dbAddUser,
   dbCallMaintenanceProcedure,
   dbAddAPIKey,
-  dbGetAPIKeyList
+  dbGetAPIKeyList,
+  dbChangeAPIKeyName
 };

--- a/app/src/middleware/authenticator.js
+++ b/app/src/middleware/authenticator.js
@@ -1,8 +1,9 @@
 import jwt from 'jsonwebtoken';
-import { verifyAPIKey } from '../controllers/remoteHost';
+import { verifyAPIKey } from '../controllers/remoteHost.js';
 
 const getToken = (request) => {
   const authorization = request.get('authorization');
+  console.log(authorization);
   if (authorization && authorization.startsWith('Bearer ')) {
     return authorization.replace('Bearer ', '');
   }
@@ -11,10 +12,11 @@ const getToken = (request) => {
 
 const authenticator = async (request, response, next) => {
   const token = getToken(request);
+  let decodedToken;
+  let prefix;
 
   if (token) {
-    const prefix = token.slice(0, 4);
-    let decodedToken;
+    prefix = token.slice(0, 4);
 
     if (prefix === 'pfx_') {
       decodedToken = await verifyAPIKey(token);
@@ -23,9 +25,7 @@ const authenticator = async (request, response, next) => {
     }
   }
 
-
-
-  if (!decodedToken || !decodedToken.id) {
+  if (!decodedToken || (!decodedToken.id && prefix !== 'pfx_')) {
     const error = new Error('Missing or invalid token.');
     error.statusCode = 401;
     next(error);

--- a/app/src/middleware/authenticator.js
+++ b/app/src/middleware/authenticator.js
@@ -1,5 +1,4 @@
-import jwt, { verify } from 'jsonwebtoken';
-import { compareWithHash } from '../utils/bcrypt';
+import jwt from 'jsonwebtoken';
 import { verifyAPIKey } from '../controllers/remoteHost';
 
 const getToken = (request) => {
@@ -18,7 +17,7 @@ const authenticator = async (request, response, next) => {
     let decodedToken;
 
     if (prefix === 'pfx_') {
-      decodedToken = await verifyAPIKey();
+      decodedToken = await verifyAPIKey(token);
     } else {
       decodedToken = jwt.verify(token, process.env.SECRET);
     }

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -4,8 +4,7 @@ import { getMonitors, getMonitor, getMonitorRuns, addMonitor, deleteMonitor, upd
 import { addPing } from '../controllers/ping.js';
 import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
-import { addAPIKey, verifyAPIKey } from '../controllers/remoteHost.js';
-import { verify } from 'jsonwebtoken';
+import { addAPIKey} from '../controllers/remoteHost.js';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitor);
@@ -21,7 +20,6 @@ router.get('/users/count', userCount);
 
 router.post('/login', login);
 
-router.post('/remoteHost', addAPIKey);
-router.get('/remoteHost', verifyAPIKey);
+router.post('/remote-host', addAPIKey);
 
 export default router;

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -4,7 +4,7 @@ import { getMonitors, getMonitor, getMonitorRuns, addMonitor, deleteMonitor, upd
 import { addPing } from '../controllers/ping.js';
 import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
-import { addAPIKey} from '../controllers/remoteHost.js';
+import { addAPIKey } from '../controllers/remoteHost.js';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitor);

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -20,7 +20,9 @@ router.get('/users/count', userCount);
 
 router.post('/login', login);
 
-router.get('/remote-host', addAPIKey);
-router.post('/remote-host', addName);
+// router.get('/remote-host')
+router.post('/remote-host', addAPIKey);
+router.put('/remote-host/:id', addName);
+
 
 export default router;

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -4,7 +4,7 @@ import { getMonitors, getMonitor, getMonitorRuns, addMonitor, deleteMonitor, upd
 import { addPing } from '../controllers/ping.js';
 import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
-import { addAPIKey } from '../controllers/remoteHost.js';
+import { addAPIKey, addName } from '../controllers/remoteHost.js';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitor);
@@ -21,5 +21,6 @@ router.get('/users/count', userCount);
 router.post('/login', login);
 
 router.get('/remote-host', addAPIKey);
+router.post('/remote-host', addName);
 
 export default router;

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -4,6 +4,8 @@ import { getMonitors, getMonitor, getMonitorRuns, addMonitor, deleteMonitor, upd
 import { addPing } from '../controllers/ping.js';
 import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
+import { addAPIKey, verifyAPIKey } from '../controllers/remoteHost.js';
+import { verify } from 'jsonwebtoken';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitor);
@@ -18,5 +20,8 @@ router.post('/users', addUser);
 router.get('/users/count', userCount);
 
 router.post('/login', login);
+
+router.post('/remoteHost', addAPIKey);
+router.get('/remoteHost', verifyAPIKey);
 
 export default router;

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -20,6 +20,6 @@ router.get('/users/count', userCount);
 
 router.post('/login', login);
 
-router.post('/remote-host', addAPIKey);
+router.get('/remote-host', addAPIKey);
 
 export default router;

--- a/app/src/utils/generateAPIKey.js
+++ b/app/src/utils/generateAPIKey.js
@@ -1,0 +1,8 @@
+import nanoid from 'nanoid';
+
+const generateAPIKey = () => {
+    const key = 'pfx_' + nanoid(); //pfx indicates that it's a key; default nanoid is 21 chars long
+    return key;
+}
+
+export default generateAPIKey;

--- a/app/src/utils/generateAPIKey.js
+++ b/app/src/utils/generateAPIKey.js
@@ -6,3 +6,5 @@ const generateAPIKey = () => {
 }
 
 export default generateAPIKey;
+
+console.log(generateAPIKey());

--- a/app/src/utils/generateAPIKey.js
+++ b/app/src/utils/generateAPIKey.js
@@ -6,5 +6,3 @@ const generateAPIKey = () => {
 }
 
 export default generateAPIKey;
-
-console.log(generateAPIKey());

--- a/app/src/utils/generateAPIKey.js
+++ b/app/src/utils/generateAPIKey.js
@@ -1,4 +1,4 @@
-import nanoid from 'nanoid';
+import {nanoid} from 'nanoid';
 
 const generateAPIKey = () => {
     const key = 'pfx_' + nanoid(); //pfx indicates that it's a key; default nanoid is 21 chars long
@@ -6,3 +6,5 @@ const generateAPIKey = () => {
 }
 
 export default generateAPIKey;
+
+console.log(generateAPIKey());

--- a/app/src/utils/generateAPIKey.js
+++ b/app/src/utils/generateAPIKey.js
@@ -1,4 +1,4 @@
-import {nanoid} from 'nanoid';
+import { nanoid } from 'nanoid';
 
 const generateAPIKey = () => {
     const key = 'pfx_' + nanoid(); //pfx indicates that it's a key; default nanoid is 21 chars long
@@ -6,5 +6,3 @@ const generateAPIKey = () => {
 }
 
 export default generateAPIKey;
-
-console.log(generateAPIKey());

--- a/database/init.sql
+++ b/database/init.sql
@@ -46,10 +46,10 @@ CREATE TABLE run (
 CREATE TABLE api_key (
   id serial, 
   api_key_hash text NOT NULL,
-  created_at timestamp NOT NULL,
-  name text,
-  PRIMARY KEY (id),
-)
+  created_at timestamp DEFAULT CURRENT_TIMESTAMP,
+  name text DEFAULT 'server_api_key',
+  PRIMARY KEY (id)
+);
 
 CREATE PROCEDURE rotate_runs()
 LANGUAGE SQL

--- a/database/init.sql
+++ b/database/init.sql
@@ -43,6 +43,14 @@ CREATE TABLE run (
   FOREIGN KEY (monitor_id) REFERENCES monitor(id) ON DELETE CASCADE
 );
 
+CREATE TABLE api_key (
+  id serial, 
+  api_key_hash text NOT NULL,
+  created_at timestamp NOT NULL,
+  name text,
+  PRIMARY KEY (id),
+)
+
 CREATE PROCEDURE rotate_runs()
 LANGUAGE SQL
 BEGIN ATOMIC

--- a/database/init.sql
+++ b/database/init.sql
@@ -48,6 +48,7 @@ CREATE TABLE api_key (
   api_key_hash text NOT NULL,
   created_at timestamp DEFAULT CURRENT_TIMESTAMP,
   name text DEFAULT 'server_api_key',
+  prefix text NOT NULL,
   PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
Started work on generating and using an API key on the backend. 

- generated API key using `nanoid` – I added the `pfx` to easily identify that it's a key (like mentioned [here](https://prefix.dev/blog/how_we_implented_api_keys)). The default `nanoid()` method is set to 21 characters. 
- added an `api_key` table to our DB. I am working on the assumption that users will be able to name the key (so they can remember which server it's tied to). It's not tied to any other tables, as I didn't think it would have any relationships with monitors or pings.
- a route `/remote-host` was added for when users want to generate a new API key
- controller with two methods was created – `addAPIKey` and `verifyAPIKey`.

I'm not sure if my `verifyAPIKey` should exist in the `remoteHost` controller; I think it should be in `authenticator.js`, except that it only needs to be in `addMonitor` in the `monitor` controller. This part feels fuzzy to me.