### PR TITLE
Api key frontend – main page & add new btn

### DIFF
--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -10,7 +10,7 @@ const addAPIKey = async (req, res, next) => {
         const prefix = apiKey.slice(0, 8);
 
         let data = await dbAddAPIKey(hash, prefix);
-        res.status(201).send({apiKey: apiKey, id: data.id, prefix: prefix});
+        res.json({apiKey: apiKey, id: data.id, prefix: prefix, name: data.name, created_at: data.created_at});
     } catch(error) {
         next(error);
     }

--- a/app/src/controllers/remoteHost.js
+++ b/app/src/controllers/remoteHost.js
@@ -41,4 +41,13 @@ const verifyAPIKey = async (req, res, next) => {
 
 };
 
-export { addAPIKey, verifyAPIKey, addName };
+const getAPIKeyList = async (req, res, next) => {
+    try {
+        const list = await dbGetAPIKeyList();
+        res.json(list);
+    } catch(error) {
+        next(error);
+    }
+};
+
+export { addAPIKey, verifyAPIKey, addName, getAPIKeyList };

--- a/app/src/middleware/authenticator.js
+++ b/app/src/middleware/authenticator.js
@@ -13,9 +13,7 @@ const getToken = (request) => {
 
 const authenticator = async (request, response, next) => {
   try {
-    console.log(request.originalUrl);
     const token = getToken(request);
-    console.log(token);
     let decodedToken;
     let prefix;
 

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -4,7 +4,7 @@ import { getMonitors, getMonitor, getMonitorRuns, addMonitor, deleteMonitor, upd
 import { addPing } from '../controllers/ping.js';
 import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
-import { addAPIKey, addName } from '../controllers/remoteHost.js';
+import { addAPIKey, addName, getAPIKeyList } from '../controllers/remoteHost.js';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitor);
@@ -20,7 +20,7 @@ router.get('/users/count', userCount);
 
 router.post('/login', login);
 
-// router.get('/remote-host')
+router.get('/remote-host', getAPIKeyList)
 router.post('/remote-host', addAPIKey);
 router.put('/remote-host/:id', addName);
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -59,7 +59,7 @@ const App = () => {
   //   const handleInitialNavigate = async () => {
   //     try {
   //       if (token) {
-  //         navigate('/api-keys');
+  //         navigate('/jobs');
   //         return;
   //       }
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -11,6 +11,7 @@ import LoginForm from './components/LoginForm';
 import { useAuth } from './context/AuthProvider';
 import { THEME_COLOR, FONT_COLOR } from './constants/colors';
 import { checkDBAdmin } from './services/users';
+import APIKeyList from './components/APIKeyList';
 
 const theme = createTheme({
   typography: {
@@ -54,28 +55,28 @@ const App = () => {
     addErrorMessage(message);
   };
 
-  useEffect(() => {
-    const handleInitialNavigate = async () => {
-      try {
-        if (token) {
-          navigate('/jobs');
-          return;
-        }
+  // useEffect(() => {
+  //   const handleInitialNavigate = async () => {
+  //     try {
+  //       if (token) {
+  //         navigate('/api-keys');
+  //         return;
+  //       }
 
-        const adminExists = await checkDBAdmin();
-        if (!adminExists) {
-          navigate('/create-user');
-          return;
-        }
+  //       const adminExists = await checkDBAdmin();
+  //       if (!adminExists) {
+  //         navigate('/create-user');
+  //         return;
+  //       }
 
-        navigate('/login');
-      } catch(error) {
-        handleAxiosError(error);
-      }
-    }
+  //       navigate('/login');
+  //     } catch(error) {
+  //       handleAxiosError(error);
+  //     }
+  //   }
 
-    handleInitialNavigate();
-  }, [token]);
+  //   handleInitialNavigate();
+  // }, [token]);
 
   return (
     <ThemeProvider theme={theme}>
@@ -101,6 +102,17 @@ const App = () => {
               />} 
             />
         </Route>
+        <Route
+          path="/api-keys"
+          // element={<ProtectedRoute />}>
+            element={
+                <APIKeyList
+                  onAxiosError={handleAxiosError}
+                  addErrorMessage={addErrorMessage}
+                  addSuccessMessage={addSuccessMessage}
+              />} 
+            />
+
         <Route 
           path="/login" 
           element={

--- a/ui/src/components/APIKeyList.jsx
+++ b/ui/src/components/APIKeyList.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import {Box, Typography, Button, Divider, Grid } from '@mui/material';
 import { getAPIKeys, addAPIKey, addAPIKeyName } from '../services/keys';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -8,16 +9,19 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { CONTAINER_COLOR } from '../constants/colors';
+import Popover from './Popover';
+
 
 const APIKeyList = (onError) => {
     const [keys, setKeys] = useState([]);
+    const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+    const [currentKey, setCurrentKey] = useState('');
 
     useEffect(() => {
         const fetchList = async () => {
             try {
                 const list = await getAPIKeys();
                 setKeys(list);
-                console.log(keys);
             } catch(error) {
                 onError(error);
             }
@@ -25,41 +29,95 @@ const APIKeyList = (onError) => {
         fetchList();
     }, []);
 
+    const handleClickAddKey = async () => {
+        try {
+            const newKey = await addAPIKey();
+            setKeys(() => keys.concat(newKey));
+            setCurrentKey(newKey.apiKey);
+            setIsConfirmOpen(true);
+        } catch (error) {
+            onError(error);
+        }
+    }
+    
+    const handleClickCopy = () => {
+        navigator.clipboard.writeText(currentKey);
+        // setIsConfirmOpen(false);
+    }
+    
+    const handleClose= () => {
+    setIsConfirmOpen(false);
+    }
+
+    const boxStyle = {
+        width: '100%',
+        padding: '20px',
+        margin: '10px',
+      };
+
     const divStyle = {
         boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
         backgroundColor: CONTAINER_COLOR,
         borderRadius: '8px',
         maxWidth: '90%'
       }
+    
+    const popoverText = () => {
+        return `This is your new key: \n ${currentKey} \n Please copy it because it will only be shown once.`
+    }
 
     return (
-        <div style={{ marginTop: '5%', marginLeft: '5%'}}>
-            <div style={divStyle}>
-                <TableContainer component={Paper}>
-                    <Table sx={{ minWidth: 650 }} aria-label="simple table">
-                        <TableHead>
-                            <TableRow>
-                                <TableCell>API Key Prefix</TableCell>
-                                <TableCell align="right">Name</TableCell>
-                                <TableCell align="right">Created on</TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                        {keys.map((key) => (
-                            <TableRow
-                            key={key.id}
-                            sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                            >
-                            <TableCell component="th" scope="row">
-                                {key.prefix}
-                            </TableCell>
-                            <TableCell align="right">{key.name}</TableCell>
-                            <TableCell align="right">{key.created_at}</TableCell>
-                            </TableRow>
-                        ))}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+        <div>
+            <div style={{ marginTop: '5%', marginLeft: '5%'}}>
+                <div style={divStyle}>
+                <Box sx={boxStyle}>
+                    <Grid container spacing={2}>
+                    <Grid item xs={9}>
+                        <Typography variant="h4" sx={{margin: '30px'}}>My API Keys</Typography>
+                    </Grid>
+                    <Grid item xs={3}>
+                        <Button sx={{ fontSize: '18px', margin: '30px' }} variant='contained' onClick={handleClickAddKey}>Add New Key
+                        </Button>
+                        <Popover 
+                        content={popoverText()}
+                        open={isConfirmOpen}
+                        onClose={handleClose}
+                        primaryButtonLabel="Copy"
+                        secondaryButtonLabel="Close"
+                        onPrimaryButtonClick={handleClickCopy}
+                        onSecondaryButtonClick={handleClose}/>
+                    </Grid>
+                    </Grid>
+                    <Divider />
+                </Box>
+                </div>
+            </div>
+            <div style={{ marginTop: '5%', marginLeft: '20%', marginRight: '20%'}}>
+                    <TableContainer component={Paper}>
+                        <Table sx={{ minWidth: 650 }} aria-label="simple table">
+                            <TableHead>
+                                <TableRow >
+                                    <TableCell style={{fontWeight:'bold'}}>API Key Prefix</TableCell>
+                                    <TableCell style={{fontWeight:'bold'}} align="right">Name</TableCell>
+                                    <TableCell style={{fontWeight:'bold'}} align="right">Created on</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                            {keys.map((key) => (
+                                <TableRow
+                                key={key.id}
+                                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                                >
+                                <TableCell component="th" scope="row">
+                                    {key.prefix}
+                                </TableCell>
+                                <TableCell align="right">{key.name}</TableCell>
+                                <TableCell align="right">{key.created_at}</TableCell>
+                                </TableRow>
+                            ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
             </div>
         </div>
     );

--- a/ui/src/components/APIKeyList.jsx
+++ b/ui/src/components/APIKeyList.jsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import { getAPIKeys, addAPIKey, addAPIKeyName } from '../services/keys';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import { CONTAINER_COLOR } from '../constants/colors';
+
+const APIKeyList = (onError) => {
+    const [keys, setKeys] = useState([]);
+
+    useEffect(() => {
+        const fetchList = async () => {
+            try {
+                const list = await getAPIKeys();
+                setKeys(list);
+                console.log(keys);
+            } catch(error) {
+                onError(error);
+            }
+        };
+        fetchList();
+    }, []);
+
+    const divStyle = {
+        boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
+        backgroundColor: CONTAINER_COLOR,
+        borderRadius: '8px',
+        maxWidth: '90%'
+      }
+
+    return (
+        <div style={{ marginTop: '5%', marginLeft: '5%'}}>
+            <div style={divStyle}>
+                <TableContainer component={Paper}>
+                    <Table sx={{ minWidth: 650 }} aria-label="simple table">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>API Key Prefix</TableCell>
+                                <TableCell align="right">Name</TableCell>
+                                <TableCell align="right">Created on</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                        {keys.map((key) => (
+                            <TableRow
+                            key={key.id}
+                            sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                            >
+                            <TableCell component="th" scope="row">
+                                {key.prefix}
+                            </TableCell>
+                            <TableCell align="right">{key.name}</TableCell>
+                            <TableCell align="right">{key.created_at}</TableCell>
+                            </TableRow>
+                        ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </div>
+        </div>
+    );
+
+};
+
+export default APIKeyList;

--- a/ui/src/components/MainPage.jsx
+++ b/ui/src/components/MainPage.jsx
@@ -10,6 +10,7 @@ import { getJobs, createJob, deleteJob, updateJob } from '../services/jobs';
 import { getSse } from '../services/sse';
 import generateWrapper from '../utils/generateWrapper';
 
+
 const MainPage = ({ onAxiosError, addErrorMessage, addSuccessMessage }) => {
   const [jobs, setJobs] = useState([]);
   const [displayWrapper, setDisplayWrapper] = useState(false);

--- a/ui/src/constants/routes.js
+++ b/ui/src/constants/routes.js
@@ -11,3 +11,6 @@ export const GET_SSE = '/sse';
 export const CREATE_USER = '/api/users';
 export const LOGIN_USER = '/api/login';
 export const USER_COUNT = '/api/users/count';
+export const GET_KEYS = '/api/remote-host';
+export const CREATE_KEY = '/api/remote-host';
+export const ADD_KEY_NAME = '/api/remote-host';

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -3,7 +3,11 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 import AuthProvider from './context/AuthProvider';
 import App from './App';
-import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/300.css';
+import '@fontsource/roboto/400.css';
+
+import '@fontsource/roboto/700.css';
+
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/ui/src/services/keys.js
+++ b/ui/src/services/keys.js
@@ -1,0 +1,16 @@
+
+import axios from 'axios';
+import { BASE_URL, GET_KEYS, CREATE_KEY, ADD_KEY_NAME } from "../constants/routes";
+
+export const getAPIKeys = async () => {
+    const { data } = await axios.get(BASE_URL + GET_KEYS);
+    return data;
+}
+
+export const addAPIKey = async() => {
+    await axios.post(BASE_URL + CREATE_KEY);
+}
+
+export const addAPIKeyName = async(id, name) => {
+    await axios.put(BASE_URL + ADD_KEY_NAME + id, name);
+}

--- a/ui/src/services/keys.js
+++ b/ui/src/services/keys.js
@@ -8,7 +8,8 @@ export const getAPIKeys = async () => {
 }
 
 export const addAPIKey = async() => {
-    await axios.post(BASE_URL + CREATE_KEY);
+    const {data} = await axios.post(BASE_URL + CREATE_KEY);
+    return data;
 }
 
 export const addAPIKeyName = async(id, name) => {


### PR DESCRIPTION
I created the page `/api-keys` to display all of the keys and added the functionality to create a new api key when desired. The new key is shown in a dialog and can be copied manually or by using the 'copy' button.

### Important
There is an issue with accessing the `/api-keys` page. In this PR, I commented out the `useEffect` on line 58 (the one that contains `handleInitialNavigate`) in `App.js`, so that you could access the `/api-keys`. Otherwise, it will not allow you to access any pages outside of `/jobs`. 
It seems to be redirecting the client, which causes the useEffect to run again and point you back to `/jobs`, but I can't understand why. We don't seem to be making a new token....but are we resetting the value of `token` to the same token each time? (I tried removing `token` from the dependencies, and that didn't help any.) Sorry for not getting further with this; I was having trouble figuring out the `AuthProvider` file – and it was getting late, so my brain was not getting sharper.

This PR can be merged before or after the above issue is solved. I chose to not leave it in draft for this reason.

![Screenshot 2023-11-06 at 10 21 45 PM](https://github.com/Sundial-Inc/server/assets/10123446/bb061165-f285-4564-9c8f-772228d5114a)

![Screenshot 2023-11-06 at 10 15 31 PM](https://github.com/Sundial-Inc/server/assets/10123446/13a22ac3-d931-44b5-b8aa-b8579d0f0aba)