### PR TITLE
Changed `handleInitialNavigate` to allow access to `/api-keys`

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { CssBaseline, createTheme, ThemeProvider} from '@mui/material'
-import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import useTemporaryMessages from './hooks/useTemporaryMessages';
 import ProtectedRoute from './components/ProtectedRoute';
 import Header from './components/Header';
@@ -39,6 +39,7 @@ const App = () => {
   const [successMessages, addSuccessMessage] = useTemporaryMessages(3000);
   const { token, clearToken } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleAxiosError = (error) => {
     console.log(error);
@@ -55,28 +56,29 @@ const App = () => {
     addErrorMessage(message);
   };
 
-  // useEffect(() => {
-  //   const handleInitialNavigate = async () => {
-  //     try {
-  //       if (token) {
-  //         navigate('/jobs');
-  //         return;
-  //       }
+  useEffect(() => {
+    const handleInitialNavigate = async () => {
+      try {
+        const adminExists = await checkDBAdmin();
+        if (!adminExists) {
+          navigate('/create-user');
+          return;
+        }
 
-  //       const adminExists = await checkDBAdmin();
-  //       if (!adminExists) {
-  //         navigate('/create-user');
-  //         return;
-  //       }
+        if (!token) {
+          navigate('/login');
+        }
 
-  //       navigate('/login');
-  //     } catch(error) {
-  //       handleAxiosError(error);
-  //     }
-  //   }
+        if (location.pathname === '/') {
+          navigate('/jobs');
+        }
+      } catch(error) {
+        handleAxiosError(error);
+      }
+    }
 
-  //   handleInitialNavigate();
-  // }, [token]);
+    handleInitialNavigate();
+  }, [token]);
 
   return (
     <ThemeProvider theme={theme}>
@@ -104,15 +106,17 @@ const App = () => {
         </Route>
         <Route
           path="/api-keys"
-          // element={<ProtectedRoute />}>
-            element={
+          element={<ProtectedRoute />}>
+            <Route
+              path=""
+              element={
                 <APIKeyList
                   onAxiosError={handleAxiosError}
                   addErrorMessage={addErrorMessage}
                   addSuccessMessage={addSuccessMessage}
-              />} 
+              />}
             />
-
+        </Route>
         <Route 
           path="/login" 
           element={

--- a/ui/src/components/APIKeyList.jsx
+++ b/ui/src/components/APIKeyList.jsx
@@ -11,7 +11,6 @@ import Paper from '@mui/material/Paper';
 import { CONTAINER_COLOR } from '../constants/colors';
 import Popover from './Popover';
 
-
 const APIKeyList = (onError) => {
     const [keys, setKeys] = useState([]);
     const [isConfirmOpen, setIsConfirmOpen] = useState(false);


### PR DESCRIPTION
- Altered conditional logic in `handleInititalNavigate` so that users could reach the `/api-keys` route
- Instead of always directing to `/jobs` when a token is present we now only direct to `/jobs` if the current path is `/`
### Thoughts
- It is perhaps a little strange to not have a root page (and react even gives a warning about one not existing in the current implementation) but for now I'm not sure what we'd put there