### PR TITLE
Retractable drawer

### DIFF
--- a/ui/src/components/DrawerList.jsx
+++ b/ui/src/components/DrawerList.jsx
@@ -1,0 +1,54 @@
+import { Box, Divider, List, ListItem, ListItemButton, ListItemText } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthProvider";
+
+const DrawerList = ({ toggleDrawer }) => {
+  const { clearToken } = useAuth();
+  const navigate = useNavigate();
+
+  const handleClickJobs = () => {
+    toggleDrawer();
+    navigate('/jobs');
+  };
+
+  const handleClickApiKeys = () => {
+    toggleDrawer();
+    navigate('/api-keys');
+  };
+
+  const handleClickLogout = () => {
+    toggleDrawer();
+    clearToken();
+    navigate('/login');
+  };
+
+  return (
+    <Box
+      sx={{ width: 250 }}
+      role="presentation"  
+    >
+      <List>
+        <ListItem>
+          <ListItemButton onClick={handleClickJobs}>
+            <ListItemText primary="Jobs" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem>
+          <ListItemButton onClick={handleClickApiKeys}>
+            <ListItemText primary="API Keys" />
+          </ListItemButton>
+        </ListItem>
+      </List>
+      <Divider />
+      <List>
+        <ListItem>
+          <ListItemButton onClick={handleClickLogout}>
+            <ListItemText primary="Logout" />
+          </ListItemButton>
+        </ListItem>
+      </List>
+    </Box>
+  );
+};
+
+export default DrawerList;

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -1,9 +1,17 @@
-import { Box, AppBar, Toolbar, Typography } from '@mui/material';
+import { Box, AppBar, Toolbar, Typography, Drawer } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import IconButton from '@mui/material/IconButton';
 import { THEME_COLOR } from '../constants/colors';
+import { useState } from 'react';
+import DrawerList from './DrawerList';
 
 const Header = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const toggleDrawer = () => {
+    setDrawerOpen(drawerOpen => !drawerOpen);
+  };
+
   return (
     <div>
       <Box sx={{ flexGrow: 1 }}>
@@ -15,9 +23,17 @@ const Header = () => {
               color="inherit"
               aria-label="open drawer"
               sx={{ mr: 2 }}
+              onClick={toggleDrawer}
             >
               <MenuIcon />
             </IconButton>
+            <Drawer
+              anchor="left"
+              open={drawerOpen}
+              onClose={toggleDrawer}  
+            >
+              <DrawerList toggleDrawer={toggleDrawer} />
+            </Drawer>
             <Typography
               variant="h6"
               noWrap


### PR DESCRIPTION
- Used MaterialUi `Drawer` component to create a retractable list of options
- The drawer opens when clicking the `MenuIcon` in the header
- New `DrawerList` component contains the options and the actions taken when they are clicked
- Current options are: Jobs, API Keys and Logout
### Future Improvements
- The options should maybe be different when the user is not logged in but the program does not allow access to these pages regardless so I don't think it's a priority right now
- The colours could be improved - its a little bland at the moment