### PR TITLE
Error logs

### DIFF
--- a/app/src/controllers/errorLog.js
+++ b/app/src/controllers/errorLog.js
@@ -1,0 +1,22 @@
+import { dbUpdateRunErrorLog } from '../db/queries.js';
+
+const updateRunErrorLog = async (req, res, next) => {
+  try {
+    const run_token = req.body.runToken;
+    const error_log = req.body.logContent;
+    const run = await dbUpdateRunErrorLog({ error_log, run_token });
+
+    if (!run) {
+      const error = Error('Unable to find run associated with that run token.');
+      error.statusCode = 404;
+      throw error;
+    }
+    res.json(run);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export {
+  updateRunErrorLog
+};

--- a/app/src/controllers/monitor.js
+++ b/app/src/controllers/monitor.js
@@ -2,8 +2,8 @@ import { nanoid } from 'nanoid';
 import { dbGetAllMonitors, dbGetRunsByMonitorId, dbAddMonitor, dbDeleteMonitor, dbUpdateMonitor, dbGetTotalRunsByMonitorId, dbGetMonitorById } from '../db/queries.js';
 import calculateTotalPages from '../utils/calculateTotalPages.js';
 import { sendNewMonitor, sendUpdatedMonitor } from './sse.js';
-// import { isSyncRequired } from '../utils/isSyncRequired.js';
-// import { triggerSync } from '../services/cli.js';
+import { isSyncRequired } from '../utils/isSyncRequired.js';
+import { triggerSync } from '../services/cli.js';
 
 const validMonitor = (monitor) => {
   if (typeof monitor !== 'object') {
@@ -83,7 +83,7 @@ const getMonitorRuns = async (req, res, next) => {
 
 const addMonitor = async (req, res, next) => {
   const { ...monitorData } = req.body;
-  // const syncMode = req.headers['x-sync-mode'];
+  const syncMode = req.headers['x-sync-mode'];
   const endpointKey = nanoid(10);
 
   const newMonitorData = {
@@ -100,7 +100,7 @@ const addMonitor = async (req, res, next) => {
 
   try {
     const monitor = await dbAddMonitor(newMonitorData);
-    // syncMode === 'CLI' ? null : await triggerSync();
+    syncMode === 'CLI' ? null : await triggerSync();
     sendNewMonitor(monitor);
     res.status(201).json(monitor);
   } catch (error) {
@@ -111,7 +111,7 @@ const addMonitor = async (req, res, next) => {
 const deleteMonitor = async (req, res, next) => {
   try {
     const id = req.params.id;
-    // const syncMode = req.headers['x-sync-mode'];
+    const syncMode = req.headers['x-sync-mode'];
     const deletedMonitor = await dbDeleteMonitor(id);
 
     if (!deletedMonitor) {
@@ -120,7 +120,7 @@ const deleteMonitor = async (req, res, next) => {
       throw error;
     }
 
-    // syncMode === 'CLI' ? null : await triggerSync();
+    syncMode === 'CLI' ? null : await triggerSync();
     res.status(204).send();
   } catch (error) {
     next(error);
@@ -130,8 +130,8 @@ const deleteMonitor = async (req, res, next) => {
 const updateMonitor = async (req, res, next) => {
   const { ...updatedMonitorData } = req.body;
   const id = req.params.id;
-  // const syncMode = req.headers['x-sync-mode'];
-  // const syncRequired = await isSyncRequired(id, updatedMonitorData);
+  const syncMode = req.headers['x-sync-mode'];
+  const syncRequired = await isSyncRequired(id, updatedMonitorData);
   if (!validUpdate(updatedMonitorData)) {
     console.log(updatedMonitorData);
     const message = (!updatedMonitorData.schedule) ? 'Missing or incorrect schedule.' : 'Some monitor attribute has an incorrect input.';
@@ -143,9 +143,9 @@ const updateMonitor = async (req, res, next) => {
   try {
     const monitor = await dbUpdateMonitor(id, updatedMonitorData);
 
-    // if (syncRequired && syncMode !== 'CLI') {
-    //   await triggerSync();
-    // }
+    if (syncRequired && syncMode !== 'CLI') {
+      await triggerSync();
+    }
 
     if (!monitor) {
       const error = Error('Unable to find monitor associated with that id.');

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -178,6 +178,20 @@ const dbUpdateNoStartRun = async (data) => {
   return rows[0];
 };
 
+
+const dbUpdateRunErrorLog = async (data) => {
+  const UPDATE_RUN = `
+    UPDATE run
+    SET error_log = $1
+    WHERE run_token = $2
+    RETURNING *
+  `;
+  const errorMessage = 'Unable to update run error log in database.';
+
+  const rows = await handleDatabaseQuery(UPDATE_RUN, errorMessage, data.error_log, data.run_token);
+  return rows[0];
+};
+
 const dbGetRunByRunToken = async (runToken) => {
   const GET_RUN = `
     SELECT * FROM run
@@ -304,6 +318,7 @@ export {
   dbAddRun,
   dbUpdateStartedRun,
   dbUpdateNoStartRun,
+  dbUpdateRunErrorLog,
   dbGetRunByRunToken,
   dbGetRunsByMonitorId,
   dbGetTotalRunsByMonitorId,

--- a/app/src/routes/api.js
+++ b/app/src/routes/api.js
@@ -5,6 +5,7 @@ import { addPing } from '../controllers/ping.js';
 import { addUser, userCount } from '../controllers/user.js';
 import { login } from '../controllers/login.js';
 import { addAPIKey, addName, getAPIKeyList } from '../controllers/remoteHost.js';
+import { updateRunErrorLog } from '../controllers/errorLog.js';
 
 router.get('/monitors', getMonitors);
 router.get('/monitors/:id', getMonitor);
@@ -13,6 +14,7 @@ router.post('/monitors', addMonitor);
 router.put('/monitors/:id', updateMonitor);
 router.delete('/monitors/:id', deleteMonitor);
 
+router.put('/runs', updateRunErrorLog);
 router.post('/pings/:endpoint_key', addPing);
 
 router.post('/users', addUser);

--- a/database/init.sql
+++ b/database/init.sql
@@ -39,6 +39,7 @@ CREATE TABLE run (
   time timestamp NOT NULL,
   duration interval,
   state states NOT NULL,
+  error_log text,
   PRIMARY KEY (id),
   FOREIGN KEY (monitor_id) REFERENCES monitor(id) ON DELETE CASCADE
 );

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.5.1",
         "cron-parser": "^4.9.0",
+        "cronstrue": "^2.43.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
@@ -6565,6 +6566,14 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "2.43.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.43.0.tgz",
+      "integrity": "sha512-FrL6gIbluwkr/d5ZhsEf13GVEgg8CYolfS/d2xZisZ/rOE3t73RKAmBbvT0Ng++9dNGZEFC8Yn26n6c3TmkLVw==",
+      "bin": {
+        "cronstrue": "bin/cli.js"
       }
     },
     "node_modules/cross-spawn": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.5.1",
     "cron-parser": "^4.9.0",
+    "cronstrue": "^2.43.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",

--- a/ui/src/components/AddJobForm.jsx
+++ b/ui/src/components/AddJobForm.jsx
@@ -4,6 +4,7 @@ import {scheduleParser} from '../utils/validateSchedule';
 import { Link, useNavigate } from 'react-router-dom';
 import PopoverButton from './PopoverButton';
 import { CONTAINER_COLOR } from '../constants/colors';
+import { scheduleString } from '../utils/scheduleString';
 
 const AddJobForm = ({ onSubmitAddForm, addErrorMessage }) => {
   const [schedule, setSchedule] = useState('');
@@ -72,7 +73,7 @@ const AddJobForm = ({ onSubmitAddForm, addErrorMessage }) => {
             sx={{padding: '5px'}}
             id="outlined-required"
             label="Schedule (required)"
-            helperText="The cron schedule string."
+            helperText={scheduleString(schedule)}
             placeholder="* * * * *"
             value={schedule}
             onChange={(e) => { setSchedule(e.target.value)}}

--- a/ui/src/components/EditForm.jsx
+++ b/ui/src/components/EditForm.jsx
@@ -6,6 +6,7 @@ import PopoverButton from './PopoverButton';
 import { useAuth } from '../context/AuthProvider';
 import { getJob } from '../services/jobs';
 import { CONTAINER_COLOR } from '../constants/colors';
+import { scheduleString } from '../utils/scheduleString';
 
 const EditForm = ({ onSubmitEditForm, addErrorMessage }) => {
   const { id } = useParams();
@@ -98,7 +99,7 @@ const EditForm = ({ onSubmitEditForm, addErrorMessage }) => {
               sx={{padding: '5px'}}
               id="outlined-required"
               label="Schedule (required)"
-              helperText="The cron schedule string."
+              helperText={scheduleString(schedule)}
               value={schedule}
               onChange={(e) => { setSchedule(e.target.value)}}
             />

--- a/ui/src/components/Run.jsx
+++ b/ui/src/components/Run.jsx
@@ -112,7 +112,6 @@ const Run = ({ run }) => {
                     </AccordionDetails>
                   </Accordion>
                   : null}
-
                 </Grid>
           }
         />

--- a/ui/src/components/Run.jsx
+++ b/ui/src/components/Run.jsx
@@ -91,7 +91,8 @@ const Run = ({ run }) => {
                     </AccordionSummary>
                     <AccordionDetails>
                       <Typography> 
-                      hello mary!
+                        {run.error_log}
+                      {/* hello mary!
                         running test cron
                         /Users/marymcdonald/launch-school/crontastic/cron-test.js:5
                             [].floor();
@@ -107,7 +108,7 @@ const Run = ({ run }) => {
                             at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:122:12)
                             at node:internal/main/run_main_module:28:49
 
-                        Node.js v21.0.0
+                        Node.js v21.0.0 */}
                       </Typography>
                     </AccordionDetails>
                   </Accordion>

--- a/ui/src/components/Run.jsx
+++ b/ui/src/components/Run.jsx
@@ -1,8 +1,13 @@
 import { ListItem, ListItemText, Grid, Typography } from '@mui/material';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import formatTime from '../utils/formatTime';
 import { ALERT_COLOR, WARNING_COLOR, OPERATIONAL_COLOR } from "../constants/colors.js"
 
 const Run = ({ run }) => {
+
   const okay = {
     backgroundColor: OPERATIONAL_COLOR,
     color: 'white',
@@ -50,29 +55,70 @@ const Run = ({ run }) => {
     borderRadius: '8px' 
   }
 
+  const accordionStyle = {
+    width: '100%',
+    padding: '5px',
+    margin: '10px',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
+    backgroundColor: colorByState,
+    borderRadius: '8px' 
+  }
+
   return ( 
-    <ListItem sx={listStyle}>
-      <ListItemText
-        primary={
-          <Grid container spacing={2}>
-            <Grid item xs={2}>
-              <Typography variant="body1" sx={{fontWeight:'bold'}}>{formatTime(run.time)}</Typography>
-            </Grid>
-            <Grid item xs={5}>
-              <Typography variant="body1">{getStateDescription(run.state)}</Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body1">{'State: ' + run.state}</Typography>
-            </Grid>
-            {run.duration && (
-              <Grid item xs={2}>
-                <Typography variant="body1">{run.duration ? run.duration.milliseconds : null}</Typography>
-              </Grid>
-            )}
-          </Grid>
-        }
-      />
-    </ListItem>
+    <div>
+      <ListItem sx={listStyle}>
+        <ListItemText
+          primary={
+                <Grid container spacing={2}>
+                  <Grid item xs={2}>
+                    <Typography variant="body1" sx={{fontWeight:'bold'}}>{formatTime(run.time)}</Typography>
+                  </Grid>
+                  <Grid item xs={5}>
+                    <Typography variant="body1">{getStateDescription(run.state)}</Typography>
+                  </Grid>
+                  <Grid item xs={2}>
+                    <Typography variant="body1">{'State: ' + run.state}</Typography>
+                  </Grid>
+                  {run.duration && (
+                    <Grid item xs={2}>
+                      <Typography variant="body1">{run.duration ? 'Duration (s): ' + run.duration.milliseconds : 'Duration (s): '+ null}</Typography>
+                    </Grid>
+                  )}
+                  {colorByState !== okay ?                   
+                  <Accordion sx={accordionStyle}>
+                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                      See Error Logs
+                    </AccordionSummary>
+                    <AccordionDetails>
+                      <Typography> 
+                      hello mary!
+                        running test cron
+                        /Users/marymcdonald/launch-school/crontastic/cron-test.js:5
+                            [].floor();
+                              ^
+
+                        TypeError: [].floor is not a function
+                            at broken (/Users/marymcdonald/launch-school/crontastic/cron-test.js:5:8)
+                            at Object.anonymous (/Users/marymcdonald/launch-school/crontastic/cron-test.js:8:1)
+                            at Module._compile (node:internal/modules/cjs/loader:1369:14)
+                            at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
+                            at Module.load (node:internal/modules/cjs/loader:1201:32)
+                            at Module._load (node:internal/modules/cjs/loader:1017:12)
+                            at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:122:12)
+                            at node:internal/main/run_main_module:28:49
+
+                        Node.js v21.0.0
+                      </Typography>
+                    </AccordionDetails>
+                  </Accordion>
+                  : null}
+
+                </Grid>
+          }
+        />
+      </ListItem>
+    </div>
+
   );
 }
  

--- a/ui/src/components/RunsList.jsx
+++ b/ui/src/components/RunsList.jsx
@@ -173,7 +173,7 @@ const RunsList = ({ onDelete, onError }) => {
               <Typography variant="body1">{job.endpoint_key}</Typography>
             </Grid>
             <Grid item xs={3}>
-              <Typography variant="body1">{job.failing ? 'Failing.' : 'All Sunny!'}</Typography>
+              <Typography variant="body1">{job.failing ? 'Failing' : 'All Sunny!'}</Typography>
             </Grid>
           </Grid>
           <Divider />

--- a/ui/src/utils/scheduleString.js
+++ b/ui/src/utils/scheduleString.js
@@ -1,0 +1,10 @@
+import cronstrue from 'cronstrue';
+
+export const scheduleString = (schedule) => {
+  try {
+    const string = cronstrue.toString(schedule);
+    return string;
+  } catch {
+    return "The cron schedule string"
+  }
+}


### PR DESCRIPTION
Added an accordion component that will appear if the monitor is not 'okay' (green) and will expand with accompanying error logs. After speaking with @davidscoding , the error logs will be stored in an attribute in the `Run` table, so no API route is needed; the error logs (if present) will be returned with the rest of the run data. 

At the moment, I just put in a fake error message until the database has that change made. Will swap it with `run.error_logs` once it's in.

Also open to design modifications! Just lmk

p.s. Added in 'Duration (s)' text because we were just displaying the duration as a number with no context in the run.

Sample of when error log accordions appear
![Screenshot 2023-11-10 at 4 07 46 PM](https://github.com/Sundial-Inc/server/assets/10123446/fb10175c-4bbd-48a4-9f07-d5fa424dd191)

When one's been opened
![Screenshot 2023-11-10 at 4 13 08 PM](https://github.com/Sundial-Inc/server/assets/10123446/058613af-7463-49c7-b9bf-cb6d096e3dbd)
