### PR TITLE
Timing issues

### DIFF
--- a/app/src/controllers/errorLog.js
+++ b/app/src/controllers/errorLog.js
@@ -1,4 +1,5 @@
 import { dbUpdateRunErrorLog } from '../db/queries.js';
+import { sendUpdatedRun } from './sse.js';
 
 const updateRunErrorLog = async (req, res, next) => {
   try {
@@ -11,6 +12,8 @@ const updateRunErrorLog = async (req, res, next) => {
       error.statusCode = 404;
       throw error;
     }
+
+    sendUpdatedRun(run);
     res.json(run);
   } catch (error) {
     next(error);

--- a/app/src/db/queries.js
+++ b/app/src/db/queries.js
@@ -215,22 +215,6 @@ const dbUpdateStartedRun = async (data) => {
   return rows[0];
 };
 
-const dbUpdateNoStartRun = async (data) => {
-  const UPDATE_RUN = `
-    UPDATE run
-    SET duration = (time - $1),
-    state = $2,
-    time = $1
-    WHERE run_token = $3
-    RETURNING *
-  `;
-  const errorMessage = 'Unable to update run in database.';
-
-  const rows = await handleDatabaseQuery(UPDATE_RUN, errorMessage, data.time, data.state, data.runToken);
-  return rows[0];
-};
-
-
 const dbUpdateRunErrorLog = async (data) => {
   const UPDATE_RUN = `
     UPDATE run
@@ -372,7 +356,6 @@ export {
   dbHandleEndPing,
   dbHandleFailPing,
   dbUpdateStartedRun,
-  dbUpdateNoStartRun,
   dbUpdateRunErrorLog,
   dbGetRunByRunToken,
   dbGetRunsByMonitorId,

--- a/database/init.sql
+++ b/database/init.sql
@@ -35,7 +35,7 @@ CREATE TYPE states AS ENUM ('started', 'completed', 'failed', 'unresolved', 'no_
 CREATE TABLE run (
   id serial,
   monitor_id integer NOT NULL,
-  run_token text,
+  run_token text UNIQUE,
   time timestamp NOT NULL,
   duration interval,
   state states NOT NULL,


### PR DESCRIPTION
## Problem
This pull request aims to solve a timing issue that was causing multiple runs being added to the database with the same run token. The sequence of events leading to this can be seen in the following diagram:
![image](https://github.com/Sundial-Inc/server/assets/102357760/9b223be0-d988-4a40-a2b7-c1d3d36e40e9)
## Solution
The logic that determines whether a run needs to be inserted or updated in the database has been moved from the `ping` controller into `queries.js`. This has resulted in more complicated SQL queries that are able to make use of PostgreSQL acid transactions to prevent runs with duplicate `run_token`s being added.

The `INSERT INTO . . . ON CONFLICT (run_token) DO UPDATE . . .` postgres syntax is used to attempt to insert a new row into the runs table and then specify an alternative update action if a row with that `run_token` already exists. We then make use of the `CASE WHEN . . . ELSE . . . END` syntax to update the `state` according to the previous `state`. There are three separate methods that handle these updates: `dbHandleStartPing`, `dbHandleEndPing` and `dbHandleFailPing`.

The `dbHandleFailPing` method uses `case WHEN xmax::text::int > 0 THEN 'updated' ELSE 'inserted' END` in order to return an extra column `case` in the query that denotes whether an update or insertion has occurred. This was necessary because it is the only way to know whether to use `sendNewRun` or `sendUpdatedRun` in the `failing` branch of the `ping` controller. I found the details for doing this here: https://stackoverflow.com/questions/34762732/how-to-find-out-if-an-upsert-was-an-update-with-postgresql-9-5-upsert
## Warning
This branch was built off the `overran` state branch so includes differences related to that also when viewing 'Files changed'.